### PR TITLE
fix: pass reasoning_content back to reasoning-capable providers

### DIFF
--- a/curro-ai/src/agents/agent.ts
+++ b/curro-ai/src/agents/agent.ts
@@ -278,6 +278,10 @@ export class AgentRunner {
       if (message.tool_calls) entry.tool_calls = message.tool_calls;
       if (message.tool_call_id) entry.tool_call_id = message.tool_call_id;
       if (message.name) entry.name = message.name;
+      // Reasoning-capable models (e.g. OpenCode Zen thinking mode, DeepSeek) require the
+      // reasoning_content of a prior assistant message to be passed back unchanged on the
+      // next request; omitting it triggers a 400 invalid_request_error.
+      if (message.reasoning_content) entry.reasoning_content = message.reasoning_content;
       built.push(entry);
     }
     return built;

--- a/curro-ai/src/agents/subagents.ts
+++ b/curro-ai/src/agents/subagents.ts
@@ -358,6 +358,8 @@ function buildProviderMessages(
     if (message.tool_calls) entry.tool_calls = message.tool_calls;
     if (message.tool_call_id) entry.tool_call_id = message.tool_call_id;
     if (message.name) entry.name = message.name;
+    // Reasoning-capable models require prior reasoning_content to be passed back unchanged.
+    if (message.reasoning_content) entry.reasoning_content = message.reasoning_content;
     built.push(entry);
   }
   return built;


### PR DESCRIPTION
OpenCode Zen thinking mode (and DeepSeek-style reasoning models) require the reasoning_content of a prior assistant message to be echoed back unchanged on the next request; omitting it triggered a 400 invalid_request_error: 'The reasoning_content in the thinking mode must be passed back to the API.'

Both buildProviderMessages implementations (main agent + sub-agents) now copy message.reasoning_content back onto the request entry when present.

<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

<!--
Describe the concrete user, product, or operational problem.
For fixes, begin with:
"Fixes an issue where users <do X> would <experience Y> when <condition>."
or:
"Resolves a problem where..."

Name the affected UI surface or workflow. Do not describe the code-level cause here.
-->

## Why This Change Was Made

<!--
In one or two sentences, explain the complete shipped solution, key design
decisions, and relevant boundaries or non-goals. Include implementation detail
only when it helps reviewers understand user-visible behavior or risk.
Avoid file-by-file narration.
-->

## User Impact

<!--
State what users, operators, or developers can now do or expect. Lead with the
concrete benefit and use user-facing language. If there is no user-visible
impact, say so plainly.
-->

## Evidence

<!--
Show the most useful proof that this change works. Screenshots, screencasts,
terminal output, focused tests, CI results, live observations, redacted logs,
and artifact links are all useful. Include before/after evidence for visual
changes when it clarifies the result.

Reviewers will inspect the code, tests, and CI. Use this section to make the
validation easy to understand, not to restate the diff.
-->
