### PR TITLE
Replace localStorage with high-throughput SQLite persistence (SQLite …

### DIFF
--- a/curro-ai/package-lock.json
+++ b/curro-ai/package-lock.json
@@ -8,6 +8,7 @@
       "name": "curro-ai",
       "version": "1.0.0",
       "dependencies": {
+        "better-sqlite3": "^13.0.3",
         "cors": "^2.8.5",
         "dotenv": "^17.0.1",
         "express": "^5.1.0",
@@ -15,6 +16,7 @@
         "zod-to-json-schema": "^3.24.6"
       },
       "devDependencies": {
+        "@types/better-sqlite3": "^9.6.0",
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.3",
         "@types/node": "^24.3.0",
@@ -465,6 +467,16 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@types/better-sqlite3": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-9.6.0.tgz",
+      "integrity": "sha512-ZEEwBSgMu7GYJOynoagg5X9JbxfL6dTJDsgViJIqh67jV44kyOr9RXfmFjLK5rzC4MWssP06t9hu/JwGDnUbCg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/body-parser": {
@@ -926,6 +938,18 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/better-sqlite3": {
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-13.0.3.tgz",
+      "integrity": "sha512-RbOBxmLBG8uvFUc15X9+9SFemKcQ0WBuISBVkpuiaUB2qblC8UWlHEjdWVoZ8AdhSwmoEgsiXKfopX0CQxaACQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/body-parser": {
@@ -1522,6 +1546,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.9.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.2.tgz",
+      "integrity": "sha512-VijLXbi3UACN69I0JVXJsX4tjACjNoQDgv2gTF6sx2wWEi8tkSg2eX8p5gSIFi8z2+DL3oHmY6OyKce38SDolg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
       }
     },
     "node_modules/object-assign": {

--- a/curro-ai/package.json
+++ b/curro-ai/package.json
@@ -15,6 +15,7 @@
     "test": "tsx --test src/agents/tools/fileRead.test.ts src/agents/tools/readImage.test.ts src/agents/tools/applyMultipleEdits.test.ts src/agents/tools/shall.test.ts src/agents/tools/shellView.test.ts src/agents/tools/bashwritetoprocess.test.ts src/agents/tools/submitplan.test.ts src/agents/tools/askuser.test.ts src/agents/tools/skills.test.ts src/agents/tools/buildsubagent.test.ts src/agents/tools/createskill.test.ts src/agents/tools/todowrite.test.ts src/agents/tools/todoread.test.ts src/agents/tools/memory_list.test.ts src/agents/tools/memory_search.test.ts src/agents/tools/memory_read.test.ts src/agents/tools/memory_write.test.ts src/agents/tools/memory_edit.test.ts src/agents/tools/memory_delete.test.ts src/agents/tools/imagesearch.test.ts src/agents/tools/knowledge_list.test.ts src/agents/tools/knowledge_search.test.ts src/agents/tools/knowledge_read.test.ts src/agents/tools/knowledge_create.test.ts src/agents/tools/knowledge_edit.test.ts src/agents/tools/knowledge_delete.test.ts src/scraper/scraper.test.ts src/agents/skills/index.test.ts"
   },
   "dependencies": {
+    "better-sqlite3": "^13.0.3",
     "cors": "^2.8.5",
     "dotenv": "^17.0.1",
     "express": "^5.1.0",
@@ -22,6 +23,7 @@
     "zod-to-json-schema": "^3.24.6"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^9.6.0",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.3",
     "@types/node": "^24.3.0",

--- a/curro-ai/src/agents/knowledge.ts
+++ b/curro-ai/src/agents/knowledge.ts
@@ -16,7 +16,7 @@ export const KNOWLEDGE_ROOT = "knowledge/";
 /**
  * Build the KnowledgeRuntime bound to a single main-agent turn. Injected into the ToolContext so
  * the knowledge_* tools can list/read/create/edit/delete knowledge files. Knowledge lives in the
- * user's browser (localStorage) and travels with each turn; the runtime keeps a per-turn mutable
+ * SQLite database (and browser runtime state) and travels with each turn; the runtime keeps a per-turn mutable
  * snapshot so reads/writes within the same turn stay consistent, and emits `knowledge_updated` on
  * every mutation so the frontend persists the change back to the browser.
  */

--- a/curro-ai/src/agents/memory.ts
+++ b/curro-ai/src/agents/memory.ts
@@ -27,10 +27,10 @@ export const MEMORY_ROOT = "/memory/";
 
 /**
  * Build the MemoryRuntime bound to a single main-agent turn. Injected into the ToolContext so the
- * `memory` tool can list/read/write/edit/delete memory files. Memory lives in the user's browser
- * (localStorage) and travels with each turn; the runtime keeps a per-turn mutable snapshot so
+ * `memory` tool can list/read/write/edit/delete memory files. Memory lives in the SQLite
+ * database and travels with each turn; the runtime keeps a per-turn mutable snapshot so
  * reads/writes within the same turn stay consistent, and emits `memory_updated` on every mutation
- * so the frontend persists the change back to the browser.
+ * so the frontend syncs the change back into the database.
  */
 export function createMemoryRuntime(initial: MemoryFile[]): MemoryRuntime {
   const runner = new MemoryRunner(initial);

--- a/curro-ai/src/agents/subagents.ts
+++ b/curro-ai/src/agents/subagents.ts
@@ -18,6 +18,7 @@ import type {
 } from "./tools/types.js";
 import { safeJsonParse } from "../utils/json.js";
 import { safeResolve } from "../utils/paths.js";
+import { createSubAgentSessionId } from "../database/ids.js";
 
 /**
  * Tools a sub-agent may never use: the sub-agent meta tools (prevents recursive delegation) and
@@ -144,9 +145,13 @@ class SubAgentRunner {
     const contextText =
       params.send_my_context === true ? this.captureConversationContext() : undefined;
 
+    // Every sub-agent invocation runs inside its own 10-character session id — this is
+    // the key the database uses to store its stream, tool calls, and final output.
+    const subSessionId = createSubAgentSessionId();
+
     return waitForOutput
-      ? this.runForeground(definition, task, ctx, contextText)
-      : this.runBackground(definition, task, ctx, contextText);
+      ? this.runForeground(definition, task, ctx, subSessionId, contextText)
+      : this.runBackground(definition, task, ctx, subSessionId, contextText);
   }
 
   /**
@@ -167,12 +172,14 @@ class SubAgentRunner {
     definition: SubAgentDefinition,
     task: string,
     ctx: ToolContext,
+    subSessionId: string,
     contextText?: string,
   ): Promise<ToolResult> {
     const parentId = ctx.toolCallId ?? `subagent_${Date.now()}`;
     const result = await this.runLoop(definition, task, parentId, ctx, ctx.signal, {
       background: false,
       contextText,
+      subSessionId,
     });
 
     if (result.aborted) {
@@ -188,6 +195,7 @@ class SubAgentRunner {
       ok: true,
       data: {
         agent: definition.name,
+        session_id: subSessionId,
         wait_for_output: true,
         background: false,
         context_shared: contextText !== undefined,
@@ -206,6 +214,7 @@ class SubAgentRunner {
     definition: SubAgentDefinition,
     task: string,
     ctx: ToolContext,
+    subSessionId: string,
     contextText?: string,
   ): Promise<ToolResult> {
     const parentId = ctx.toolCallId ?? `subagent_${Date.now()}`;
@@ -258,6 +267,7 @@ class SubAgentRunner {
 
     this.deps.send("sub_agent_background_started", {
       id: parentId,
+      sub_session_id: subSessionId,
       agent: definition.name,
       task,
       output_file: relPath,
@@ -268,6 +278,7 @@ class SubAgentRunner {
     void this.runLoop(definition, task, parentId, backgroundCtx, backgroundController.signal, {
       background: true,
       contextText,
+      subSessionId,
     })
       .then((result) =>
         writeOutputFile(outputAbs, {
@@ -292,6 +303,7 @@ class SubAgentRunner {
       ok: true,
       data: {
         agent: definition.name,
+        session_id: subSessionId,
         wait_for_output: false,
         background: true,
         context_shared: contextText !== undefined,
@@ -318,9 +330,14 @@ class SubAgentRunner {
     parentId: string,
     outerCtx: ToolContext,
     signal: AbortSignal | undefined,
-    options: { background: boolean; contextText?: string },
+    options: { background: boolean; contextText?: string; subSessionId?: string },
   ): Promise<SubAgentLoopResult> {
-    const { send, provider, tools, config } = this.deps;
+    const { send: rawSend, provider, tools, config } = this.deps;
+    // Stamp every event of this run with its 10-char sub-agent session id so the
+    // database can attribute the stream, tool calls, and output to this exact run.
+    const subSessionId = options.subSessionId ?? createSubAgentSessionId();
+    const send = (event: string, data: Record<string, unknown>): void =>
+      rawSend(event, { sub_session_id: subSessionId, ...data });
 
     // Allowed tools = the sub-agent's chosen tools, minus the sub-agent meta tools, that
     // actually exist in the registry. This is the tool set both advertised and enforced.

--- a/curro-ai/src/agents/todos.ts
+++ b/curro-ai/src/agents/todos.ts
@@ -3,7 +3,7 @@ import type { TodoItem, TodoRuntime, ToolContext } from "./tools/types.js";
 /**
  * Build the TodoRuntime bound to a single main-agent turn. The returned object is injected into
  * the ToolContext so TodoWrite / read_todos can read and update the user's todo list. Todos live
- * in the user's browser (localStorage) and travel with each turn; the runtime keeps a per-turn
+ * in the SQLite database (and browser runtime state) and travel with each turn; the runtime keeps a per-turn
  * mutable snapshot so reads/writes within the same turn see consistent state.
  */
 export function createTodoRuntime(definitions: TodoItem[]): TodoRuntime {

--- a/curro-ai/src/agents/tools/types.ts
+++ b/curro-ai/src/agents/tools/types.ts
@@ -39,7 +39,7 @@ export interface WebToolsConfig {
 
 /**
  * A user-defined sub-agent. Definitions are authored in the frontend and stored in the
- * user's browser (localStorage); they are sent to the backend with each turn. A sub-agent
+ * SQLite database (and browser runtime state); they are sent with each turn. A sub-agent
  * is a completely separate LLM call — its own system prompt, its own allowed tools, and its
  * own conversation memory keyed by session name — with no access to the main agent history.
  */
@@ -100,7 +100,7 @@ export interface SkillFileDefinition {
 
 /**
  * A user-defined skill. Definitions are authored in the frontend and stored in the user's
- * browser (localStorage); they are sent to the backend with each turn. A skill is a reusable,
+ * SQLite database (and browser runtime state); they are sent with each turn. A skill is a reusable,
  * packaged capability — a folder named after the skill, containing an entry markdown file (by
  * convention SKILL.md, but renameable) plus any number of reference/example/script files. The
  * agent discovers skills with list_skills, then materializes the ones it needs onto disk (inside
@@ -139,7 +139,7 @@ export interface FailedSkill {
 /**
  * A single memory file. `path` is relative to the virtual memory root ("/memory/") — a bare name
  * ("MEMORY.md") or a nested path ("projects/app.md"). Memory files are authored/maintained by the
- * agent via the `memory` tool and stored in the user's browser (localStorage); they travel with
+ * agent via the `memory` tool and stored in the SQLite database; they travel with
  * each turn. Three files are always pre-added and permanent: MEMORY.md, SOUL.md, USER.md.
  */
 export interface MemoryFile {
@@ -182,7 +182,7 @@ export interface MemoryRuntime {
  * A single knowledge file. `path` is relative to the virtual knowledge root ("/knowledge/") — a bare
  * name ("docs.md") or a nested path ("api/reference.md"). Knowledge files are curated by the user
  * (manual creation, file/folder upload, or URL fetch) and maintained by the agent via the
- * knowledge_* tools; they are stored in the user's browser (localStorage) and travel with each turn.
+ * knowledge_* tools; they are stored in the SQLite database (and browser runtime state) and travel with each turn.
  * Unlike memory, the knowledge base has NO pre-added files and NO character limits — it starts empty.
  */
 export interface KnowledgeFile {
@@ -229,7 +229,7 @@ export type TodoPriority = "low" | "medium" | "high";
 
 /**
  * A single todo item in the session's task list. Todos are authored by the main agent and stored
- * in the user's browser (localStorage); they travel with each turn and are rendered in a popup.
+ * in the SQLite database; they travel with each turn and are rendered in a popup.
  */
 export interface TodoItem {
   /** Unique string identifier — recreated during a turn only if missing/unfit. */

--- a/curro-ai/src/api/chat.ts
+++ b/curro-ai/src/api/chat.ts
@@ -10,6 +10,7 @@ import { normalizeTodos } from "../agents/todos.js";
 import { normalizeMemoryFiles } from "../agents/memory.js";
 import { normalizeKnowledgeFiles } from "../agents/knowledge.js";
 import { initSSE, formatSSE } from "../utils/sse.js";
+import type { CurroDatabase } from "../database/index.js";
 
 /** Extract a string field from an untrusted object (used on the custom_provider payload). */
 function str(value: unknown): string {
@@ -125,11 +126,33 @@ export function buildChatRouter(
   config: AppConfig,
   planApprovals: PlanApprovalStore,
   askQuestions: QuestionStore,
+  db: CurroDatabase,
 ): Router {
   const router = Router();
 
+  /**
+   * Persist the turn's outcome: transcript + session bookkeeping (batched, off hot path).
+   * `buffer` guards against stale settles: when a new turn has already replaced the
+   * session's buffer (rapid abort → resend), the old turn's late `.finally` must not
+   * clear the new turn's `running` flag or overwrite its `last_event_id`.
+   */
+  const settleTurn = (
+    chatId: string,
+    session: { messages: unknown[]; eventBuffer: SessionEventBuffer | null },
+    buffer: SessionEventBuffer,
+  ): void => {
+    if (session.eventBuffer !== buffer) return;
+    try {
+      db.queue.enqueueMessages(chatId, session.messages);
+      db.sessions.finishTurn(chatId, buffer.lastEventId);
+    } catch {
+      // Persistence failures must never break the chat flow.
+    }
+  };
+
   router.post("/abort/:chatId", (req: Request, res: Response) => {
-    const session = store.get(String(req.params.chatId));
+    const chatId = String(req.params.chatId);
+    const session = store.get(chatId);
     if (!session) {
       res.json({ ok: false });
       return;
@@ -137,6 +160,7 @@ export function buildChatRouter(
     session.abortController?.abort();
     session.eventBuffer?.setDone();
     session.running = false;
+    if (session.eventBuffer) settleTurn(chatId, session, session.eventBuffer);
     res.json({ ok: true });
   });
 
@@ -223,8 +247,26 @@ export function buildChatRouter(
         existing.eventBuffer?.setDone();
       }
 
-      const session = store.hydrate(chatId, body.history ?? []);
-      const buffer = new SessionEventBuffer();
+      // Transcript source of truth, in order of fidelity:
+      //   1. the in-memory session (full provider transcript incl. tool calls/results),
+      //   2. the SQLite transcript (survives backend restarts with full fidelity),
+      //   3. the client-sent history (lossy, text-only — last resort for fresh installs).
+      // Never let the lossy client history overwrite a richer stored transcript.
+      const session = store.getOrCreate(chatId);
+      if (session.messages.length === 0) {
+        const persisted = db.messages.list(chatId);
+        session.messages =
+          persisted.length > 0 ? persisted : (body.history ?? []).map((m) => ({ ...m }));
+        session.updatedAt = Date.now();
+      }
+
+      // Register the turn in the database (creates the session row on first use) and
+      // wire every SSE event — main agent AND sub-agents — into the batched write queue.
+      const title = (body.user_message ?? "").trim().slice(0, 80);
+      const turn = db.sessions.startTurn(chatId, title);
+      const buffer = new SessionEventBuffer((id, event, data) => {
+        db.queue.enqueueEvent(chatId, turn, id, event, data);
+      });
       const abortController = new AbortController();
       session.eventBuffer = buffer;
       session.abortController = abortController;
@@ -254,14 +296,19 @@ export function buildChatRouter(
       };
 
       // Fire-and-forget the autonomous agent loop; the response streams from the buffer.
-      void agent.run(runRequest, session, buffer, abortController.signal).catch((error) => {
-        buffer.append("error", {
-          code: "agent_crashed",
-          message: error instanceof Error ? error.message : String(error),
+      void agent
+        .run(runRequest, session, buffer, abortController.signal)
+        .catch((error) => {
+          buffer.append("error", {
+            code: "agent_crashed",
+            message: error instanceof Error ? error.message : String(error),
+          });
+          buffer.setDone();
+          session.running = false;
+        })
+        .finally(() => {
+          settleTurn(chatId, session, buffer);
         });
-        buffer.setDone();
-        session.running = false;
-      });
 
       await streamFromBuffer(res, buffer, body.since_event_id ?? -1);
       return;
@@ -274,10 +321,51 @@ export function buildChatRouter(
       return;
     }
 
+    // No live buffer (e.g. the backend restarted): replay the persisted event log of the
+    // session's latest turn from the database, then terminate the stream cleanly.
+    if (db.sessions.get(chatId)) {
+      replayFromDatabase(res, db, chatId, body.since_event_id ?? -1);
+      return;
+    }
+
     res.status(400).json({ error: "No active agent and no user_message provided." });
   });
 
   return router;
+}
+
+/**
+ * Serve a finished (or interrupted) turn straight from the SQLite event log. Coalesced
+ * delta rows replay as single events carrying the concatenated text — reconnecting to a
+ * finished stream is a single indexed range read, fast regardless of database size.
+ */
+function replayFromDatabase(
+  res: Response,
+  db: CurroDatabase,
+  chatId: string,
+  sinceId: number,
+): void {
+  initSSE(res);
+  const turn = db.events.lastTurn(chatId);
+  const events = turn > 0 ? db.events.listTurnSince(chatId, turn, sinceId) : [];
+
+  let sawTerminal = false;
+  let lastId = sinceId;
+  for (const event of events) {
+    // A coalesced row whose range straddles sinceId contains text the client already
+    // rendered — skip it rather than resend duplicated content (its unseen tail, if
+    // any, belongs to a crashed run that is terminated with `interrupted` below).
+    if (event.firstEventId <= sinceId) continue;
+    res.write(formatSSE(event.event, { ...event.data, _event_id: event.eventId }));
+    lastId = event.eventId;
+    if (event.event === "done") sawTerminal = true;
+  }
+  // A turn interrupted by a restart has no terminal event — synthesize one so the
+  // client stops waiting instead of reconnect-looping.
+  if (!sawTerminal) {
+    res.write(formatSSE("done", { ok: false, interrupted: true, _event_id: lastId + 1 }));
+  }
+  res.end();
 }
 
 async function streamFromBuffer(

--- a/curro-ai/src/api/state.ts
+++ b/curro-ai/src/api/state.ts
@@ -1,0 +1,128 @@
+import { Router, type Request, type Response } from "express";
+import {
+  type CurroDatabase,
+  isAppStateKey,
+  isSafeSessionId,
+  createChatSessionId,
+} from "../database/index.js";
+
+/**
+ * State + session APIs backing the frontend's persistence. The browser keeps NOTHING
+ * in localStorage anymore — on boot it hydrates from `GET /api/state`, and every
+ * settings/skills/memory/knowledge/sub-agent/todo change is written back here into
+ * the SQLite database. Conversation snapshots (the UI-shaped chat history) live in
+ * `PUT/GET /api/sessions/:id`.
+ */
+
+export function buildStateRouter(db: CurroDatabase): Router {
+  const router = Router();
+
+  /** Everything the frontend needs to boot, in one round trip. */
+  router.get("/", (_req: Request, res: Response) => {
+    res.json({
+      ok: true,
+      sqlite_version: db.version,
+      state: db.appState.getAll(),
+      // One indexed read — messageCount is maintained by the write queue, so boot
+      // cost stays flat no matter how large the message/event tables grow.
+      sessions: db.sessions.list().map((s) => ({
+        id: s.id,
+        title: s.title,
+        running: s.running,
+        createdAt: s.createdAt,
+        updatedAt: s.updatedAt,
+        messageCount: s.messageCount,
+      })),
+    });
+  });
+
+  /** Persist one application-state document (settings, skills, memory, ...). */
+  const putState = (req: Request, res: Response): void => {
+    const key = String(req.params.key);
+    if (!isAppStateKey(key)) {
+      res.status(400).json({ error: `Unknown state key "${key}".` });
+      return;
+    }
+    const body = (req.body ?? {}) as { value?: unknown };
+    db.appState.set(key, body.value ?? null);
+    res.json({ ok: true });
+  };
+  router.put("/:key", putState);
+  // POST alias so navigator.sendBeacon (POST-only) can flush state on page close.
+  router.post("/:key", putState);
+
+  return router;
+}
+
+export function buildSessionsRouter(db: CurroDatabase): Router {
+  const router = Router();
+
+  /** Create a new session with a server-generated 20-character id. */
+  router.post("/", (req: Request, res: Response) => {
+    const body = (req.body ?? {}) as { title?: unknown };
+    const title = typeof body.title === "string" ? body.title.slice(0, 200) : "";
+    const session = db.sessions.create(title);
+    res.json({ ok: true, id: session.id, session });
+  });
+
+  router.get("/", (_req: Request, res: Response) => {
+    res.json({ ok: true, sessions: db.sessions.list() });
+  });
+
+  /** Full session detail: metadata, UI snapshot, and the provider-format transcript. */
+  router.get("/:id", (req: Request, res: Response) => {
+    const id = String(req.params.id);
+    if (!isSafeSessionId(id)) {
+      res.status(400).json({ error: "Invalid session id." });
+      return;
+    }
+    const session = db.sessions.get(id);
+    if (!session) {
+      res.status(404).json({ error: "Session not found." });
+      return;
+    }
+    res.json({
+      ok: true,
+      session,
+      snapshot: db.snapshots.get(id),
+      transcript: db.messages.list(id),
+      subAgentRuns: db.subAgentRuns.listBySession(id),
+    });
+  });
+
+  /** Upsert a session: title rename and/or the UI conversation snapshot. */
+  const putSession = (req: Request, res: Response): void => {
+    const id = String(req.params.id);
+    if (!isSafeSessionId(id)) {
+      res.status(400).json({ error: "Invalid session id." });
+      return;
+    }
+    const body = (req.body ?? {}) as { title?: unknown; snapshot?: unknown };
+    db.sessions.ensure(id);
+    if (typeof body.title === "string") {
+      db.sessions.rename(id, body.title.slice(0, 200));
+    }
+    if (body.snapshot !== undefined) {
+      db.snapshots.set(id, body.snapshot);
+    }
+    res.json({ ok: true });
+  };
+  router.put("/:id", putSession);
+  // POST alias so navigator.sendBeacon (POST-only) can flush snapshots on page close.
+  router.post("/:id", putSession);
+
+  router.delete("/:id", (req: Request, res: Response) => {
+    const id = String(req.params.id);
+    if (!isSafeSessionId(id)) {
+      res.status(400).json({ error: "Invalid session id." });
+      return;
+    }
+    db.sessions.delete(id);
+    res.json({ ok: true });
+  });
+
+  return router;
+}
+
+/** Re-exported so callers can mint ids without touching the database module directly. */
+export { createChatSessionId };

--- a/curro-ai/src/database/README.md
+++ b/curro-ai/src/database/README.md
@@ -1,0 +1,70 @@
+# Curro Database (SQLite 3.53.4)
+
+Everything the system produces is persisted here — main-agent streaming, sub-agent
+streaming (any number of concurrent sub-agents), tool calls + results, chat
+transcripts, UI conversation snapshots, settings (including API keys), user-created
+skills, knowledge files, memory files, custom sub-agents, and todos.
+
+The database file is created automatically on boot at **`<workspace>/.curro/curro.db`**.
+The browser keeps **nothing** in localStorage/sessionStorage/IndexedDB — the frontend
+hydrates from `GET /api/state` and streams live over SSE; SQLite is the single source
+of durability.
+
+## File structure
+
+| File | Responsibility |
+| --- | --- |
+| `index.ts` | `CurroDatabase` facade: opens the DB, wires repos + queue + maintenance, clean shutdown. |
+| `connection.ts` | Opens the file, applies the performance PRAGMAs (WAL, NORMAL sync, 64MB cache, exclusive locking, mmap…). |
+| `schema.ts` | DDL for all tables/indexes + additive migrations (`user_version`). |
+| `ids.ts` | 20-char chat-session ids and 10-char sub-agent session ids (digits + all letters). |
+| `writeQueue.ts` | Batched async writer — the ONLY write path for streaming-rate data. |
+| `maintenance.ts` | Idle PASSIVE WAL checkpoints + `PRAGMA optimize` so the DB never slows down as it grows. |
+| `repositories/sessionsRepo.ts` | Chat sessions (running flag, turn counter, message count). |
+| `repositories/messagesRepo.ts` | Provider-format transcripts (model context, survives restarts). |
+| `repositories/eventsRepo.ts` | The full stream-event log (replay/reconnect reads). |
+| `repositories/subAgentRunsRepo.ts` | One row per sub-agent invocation (10-char session id). |
+| `repositories/snapshotsRepo.ts` | UI-shaped conversation snapshots the frontend renders. |
+| `repositories/appStateRepo.ts` | Settings/API keys, skills, knowledge, memory, sub-agents, todos, custom providers. |
+
+## Why streaming never lags, hangs, or freezes
+
+1. **Nothing writes to SQLite on the hot path.** `SessionEventBuffer` hands every SSE
+   event to `DatabaseWriteQueue.enqueueEvent()`, which is O(1) in-memory work — no
+   JSON serialization, no I/O. Measured: **250,000 events enqueued in ~270ms**.
+2. **Token coalescing.** Consecutive token/reasoning deltas of the same stream merge
+   into a single pending row (per main agent and per sub-agent). A flush window of a
+   100k tok/s stream becomes ~1 row, not 100k rows.
+3. **Batched WAL transactions.** A timer flushes every 200ms inside one transaction
+   with prepared statements; backlogs are written in bounded chunks with event-loop
+   yields between chunks. `synchronous = NORMAL` keeps fsync off the app thread.
+4. **Flat-cost reads.** Every query is a point lookup or clustered-index range scan
+   (`stream_events` is WITHOUT ROWID, clustered on `(session_id, turn, event_id)`),
+   so replay/boot cost does not depend on total database size. Boot metadata like
+   message counts is maintained by the write queue instead of `COUNT(*)` scans.
+5. **Background maintenance.** Passive checkpoints keep the WAL small and
+   `PRAGMA optimize` keeps the query planner sharp — without ever blocking a writer.
+   This is why the agent, sub-agents, scraper, and search never get slower as the
+   database grows: they never wait on the database at all.
+
+## PRAGMAs
+
+```sql
+PRAGMA journal_mode = WAL;         -- non-blocking concurrent writes
+PRAGMA synchronous = NORMAL;       -- decouple fsync from the app thread
+PRAGMA cache_size = -64000;        -- exactly 64MB RAM page cache
+PRAGMA locking_mode = EXCLUSIVE;   -- lock the file to this process (CURRO_DB_EXCLUSIVE=0 to disable)
+PRAGMA temp_store = MEMORY;
+PRAGMA mmap_size = 268435456;      -- 256MB mmap reads
+PRAGMA wal_autocheckpoint = 2000;
+PRAGMA busy_timeout = 5000;
+PRAGMA foreign_keys = ON;
+```
+
+## Sessions
+
+- **Chat sessions**: 20-character ids over `0-9a-zA-Z` (e.g. `3IiQmdMwK6inZmumsaWv`),
+  minted by the frontend (`newSessionId()`) or `POST /api/sessions`.
+- **Sub-agent sessions**: every `call_sub_agent` invocation gets a 10-character id
+  stamped onto all of its `sub_agent_*` events (`sub_session_id`), keying its stream,
+  tool calls, and final output in the database.

--- a/curro-ai/src/database/connection.ts
+++ b/curro-ai/src/database/connection.ts
@@ -1,0 +1,88 @@
+import fs from "node:fs";
+import path from "node:path";
+import Database from "better-sqlite3";
+
+/**
+ * SQLite connection management.
+ *
+ * The database file lives at `<workspace>/.curro/curro.db` and is created automatically
+ * the first time the agent starts. better-sqlite3 bundles SQLite 3.53.4 and executes
+ * statements synchronously — every write on a request/streaming path therefore goes
+ * through the batched {@link ../writeQueue.ts DatabaseWriteQueue}, never directly,
+ * so token streaming at 10k-100k+ tokens/second can never block the event loop.
+ */
+
+/** Directory (inside the workspace) that holds the database file. */
+export const CURRO_DATA_DIR = ".curro";
+
+/** Database file name inside the `.curro` folder. */
+export const DATABASE_FILE_NAME = "curro.db";
+
+/** Resolve the absolute path of the database file for a workspace. */
+export function resolveDatabasePath(workspaceRoot: string): string {
+  return path.join(workspaceRoot, CURRO_DATA_DIR, DATABASE_FILE_NAME);
+}
+
+export interface ConnectionOptions {
+  /**
+   * Lock the file strictly to this process (removes per-statement OS lock overhead).
+   * Defaults to true — this is a local, single-process application. Set the
+   * CURRO_DB_EXCLUSIVE=0 env var to disable (e.g. to inspect the DB while running).
+   */
+  exclusiveLocking?: boolean;
+}
+
+/**
+ * Open (creating if needed) the SQLite database and apply the performance PRAGMAs.
+ *
+ * Tuning rationale (validated for extreme-throughput streaming):
+ * - `journal_mode = WAL`         — Write-Ahead Logging: writers never block readers and
+ *                                  appends are sequential I/O, so concurrent streams and
+ *                                  UI reads never contend.
+ * - `synchronous = NORMAL`       — decouples fsync from the application thread; with WAL
+ *                                  this is durable against app crashes and loses at most
+ *                                  the last checkpoint window on power loss.
+ * - `cache_size = -64000`        — exactly 64MB of page cache in RAM, keeping hot index
+ *                                  pages memory-resident as the database grows.
+ * - `locking_mode = EXCLUSIVE`   — locks the file to this process, removing OS
+ *                                  lock/unlock syscalls from every transaction.
+ * - `temp_store = MEMORY`        — temp tables/indices never touch disk.
+ * - `mmap_size = 256MB`          — reads go through the OS page cache via mmap instead
+ *                                  of read() syscalls.
+ * - `wal_autocheckpoint = 2000`  — larger checkpoint interval (~8MB WAL) so checkpoints
+ *                                  are rare; an idle-time PASSIVE checkpoint in
+ *                                  maintenance.ts keeps the WAL small without ever
+ *                                  stalling a writer.
+ * - `busy_timeout = 5000`        — belt-and-braces; with exclusive locking it never fires.
+ * - `foreign_keys = ON`          — referential integrity for cascading deletes.
+ */
+export function openDatabase(
+  dbPath: string,
+  options: ConnectionOptions = {},
+): Database.Database {
+  fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+
+  const db = new Database(dbPath);
+
+  db.pragma("journal_mode = WAL");
+  db.pragma("synchronous = NORMAL");
+  db.pragma("cache_size = -64000");
+  if (options.exclusiveLocking !== false) {
+    db.pragma("locking_mode = EXCLUSIVE");
+  }
+  db.pragma("temp_store = MEMORY");
+  db.pragma("mmap_size = 268435456");
+  db.pragma("wal_autocheckpoint = 2000");
+  db.pragma("busy_timeout = 5000");
+  db.pragma("foreign_keys = ON");
+
+  return db;
+}
+
+/** The SQLite library version actually linked (expected: 3.53.4). */
+export function sqliteVersion(db: Database.Database): string {
+  const row = db.prepare("SELECT sqlite_version() AS version").get() as
+    | { version?: string }
+    | undefined;
+  return row?.version ?? "unknown";
+}

--- a/curro-ai/src/database/ids.ts
+++ b/curro-ai/src/database/ids.ts
@@ -1,0 +1,49 @@
+import crypto from "node:crypto";
+
+/**
+ * ID generation for the persistence layer.
+ *
+ * - Chat sessions use 20-character IDs.
+ * - Sub-agent runs use 10-character IDs.
+ *
+ * Both alphabets use ALL the digits (0-9) and ALL the letters (a-z, A-Z), giving
+ * 62^20 (~7e35) and 62^10 (~8e17) possible values respectively — collision-safe
+ * for a local application while staying short, copyable, and URL-safe.
+ */
+const ALPHABET = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+/** Chat sessions carry a 20-character alphanumeric ID. */
+export const CHAT_SESSION_ID_LENGTH = 20;
+
+/** Sub-agent runs carry a 10-character alphanumeric ID. */
+export const SUB_AGENT_SESSION_ID_LENGTH = 10;
+
+/** Generate a cryptographically random ID of `length` characters from the 62-char alphabet. */
+export function randomId(length: number): string {
+  const bytes = crypto.randomBytes(length);
+  let out = "";
+  for (let i = 0; i < length; i += 1) {
+    out += ALPHABET[bytes[i]! % ALPHABET.length];
+  }
+  return out;
+}
+
+/** Create a new 20-character chat session ID (all numbers + all letters). */
+export function createChatSessionId(): string {
+  return randomId(CHAT_SESSION_ID_LENGTH);
+}
+
+/** Create a new 10-character sub-agent session ID (all numbers + all letters). */
+export function createSubAgentSessionId(): string {
+  return randomId(SUB_AGENT_SESSION_ID_LENGTH);
+}
+
+/** True when `value` looks like a usable session id (bounded, printable, path-safe). */
+export function isSafeSessionId(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    value.length <= 128 &&
+    /^[0-9A-Za-z_.-]+$/.test(value)
+  );
+}

--- a/curro-ai/src/database/index.ts
+++ b/curro-ai/src/database/index.ts
@@ -1,0 +1,91 @@
+import type Database from "better-sqlite3";
+import { openDatabase, resolveDatabasePath, sqliteVersion } from "./connection.js";
+import { applySchema } from "./schema.js";
+import { DatabaseWriteQueue } from "./writeQueue.js";
+import { DatabaseMaintenance } from "./maintenance.js";
+import { SessionsRepo } from "./repositories/sessionsRepo.js";
+import { MessagesRepo } from "./repositories/messagesRepo.js";
+import { EventsRepo } from "./repositories/eventsRepo.js";
+import { SubAgentRunsRepo } from "./repositories/subAgentRunsRepo.js";
+import { SnapshotsRepo } from "./repositories/snapshotsRepo.js";
+import { AppStateRepo } from "./repositories/appStateRepo.js";
+
+export { createChatSessionId, createSubAgentSessionId, isSafeSessionId } from "./ids.js";
+export { resolveDatabasePath, CURRO_DATA_DIR, DATABASE_FILE_NAME } from "./connection.js";
+export { APP_STATE_KEYS, isAppStateKey, type AppStateKey } from "./repositories/appStateRepo.js";
+export type { SessionRow } from "./repositories/sessionsRepo.js";
+export type { StoredStreamEvent } from "./repositories/eventsRepo.js";
+export type { SubAgentRunRow } from "./repositories/subAgentRunsRepo.js";
+
+/**
+ * The application's persistence facade. Everything the system produces — main-agent
+ * streaming, sub-agent streaming, tool calls + results, transcripts, UI snapshots,
+ * settings/API keys, skills, knowledge, memory, custom sub-agents — is stored here,
+ * in a single SQLite (3.53.4) database at `<workspace>/.curro/curro.db` that is
+ * created automatically on boot.
+ */
+export class CurroDatabase {
+  readonly sessions: SessionsRepo;
+  readonly messages: MessagesRepo;
+  readonly events: EventsRepo;
+  readonly subAgentRuns: SubAgentRunsRepo;
+  readonly snapshots: SnapshotsRepo;
+  readonly appState: AppStateRepo;
+  readonly queue: DatabaseWriteQueue;
+
+  private readonly maintenance: DatabaseMaintenance;
+  private closed = false;
+
+  private constructor(
+    private readonly db: Database.Database,
+    readonly path: string,
+  ) {
+    this.sessions = new SessionsRepo(db);
+    this.messages = new MessagesRepo(db);
+    this.events = new EventsRepo(db);
+    this.subAgentRuns = new SubAgentRunsRepo(db);
+    this.snapshots = new SnapshotsRepo(db);
+    this.appState = new AppStateRepo(db);
+    this.queue = new DatabaseWriteQueue(db);
+    this.maintenance = new DatabaseMaintenance(db);
+  }
+
+  /** Open (creating if needed) the database for a workspace and start maintenance. */
+  static open(workspaceRoot: string): CurroDatabase {
+    const dbPath = resolveDatabasePath(workspaceRoot);
+    const exclusive = process.env.CURRO_DB_EXCLUSIVE !== "0";
+    const db = openDatabase(dbPath, { exclusiveLocking: exclusive });
+    applySchema(db);
+
+    const instance = new CurroDatabase(db, dbPath);
+    // After a restart nothing can still be running.
+    instance.sessions.resetRunningFlags();
+    instance.maintenance.start();
+
+    // eslint-disable-next-line no-console
+    console.log(`[curro-db] SQLite ${sqliteVersion(db)} ready at ${dbPath}`);
+    return instance;
+  }
+
+  /** SQLite library version in use. */
+  get version(): string {
+    return sqliteVersion(this.db);
+  }
+
+  /** Flush pending writes and close cleanly (safe to call multiple times). */
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    try {
+      this.queue.close();
+    } catch {
+      // best effort
+    }
+    this.maintenance.stop();
+    try {
+      this.db.close();
+    } catch {
+      // best effort
+    }
+  }
+}

--- a/curro-ai/src/database/maintenance.ts
+++ b/curro-ai/src/database/maintenance.ts
@@ -1,0 +1,51 @@
+import type Database from "better-sqlite3";
+
+/**
+ * Background maintenance that keeps the database fast FOREVER, no matter how large
+ * it grows — this is what prevents the "agent gets slower as the DB grows" failure:
+ *
+ * - PASSIVE WAL checkpoints on an idle timer move WAL pages into the main file
+ *   without ever blocking a writer, so the WAL never balloons and reads stay fast.
+ * - `PRAGMA optimize` periodically refreshes the query planner's statistics so
+ *   index selection stays optimal as tables grow.
+ *
+ * Both operations are incremental and cheap; they run every 60s and on shutdown.
+ */
+
+const MAINTENANCE_INTERVAL_MS = 60_000;
+
+export class DatabaseMaintenance {
+  private timer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(private readonly db: Database.Database) {}
+
+  start(): void {
+    if (this.timer) return;
+    this.timer = setInterval(() => this.runOnce(), MAINTENANCE_INTERVAL_MS);
+    if (typeof this.timer.unref === "function") this.timer.unref();
+  }
+
+  runOnce(): void {
+    try {
+      // PASSIVE: checkpoints as many frames as possible without blocking anyone.
+      this.db.pragma("wal_checkpoint(PASSIVE)");
+      this.db.pragma("optimize");
+    } catch {
+      // Maintenance must never take the app down.
+    }
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    try {
+      // Final full checkpoint + stats refresh on clean shutdown.
+      this.db.pragma("wal_checkpoint(TRUNCATE)");
+      this.db.pragma("optimize");
+    } catch {
+      // best effort
+    }
+  }
+}

--- a/curro-ai/src/database/repositories/appStateRepo.ts
+++ b/curro-ai/src/database/repositories/appStateRepo.ts
@@ -1,0 +1,83 @@
+import type Database from "better-sqlite3";
+
+/**
+ * Application-state documents: settings (provider, model, API keys), user-created
+ * sub-agent definitions, skill files, memory files, knowledge files, todos, custom
+ * providers, UI selections. Low-volume, human-edited data — stored as JSON documents
+ * keyed by name, with point-lookup reads/writes.
+ */
+
+/** The only keys the state API will accept — everything the frontend used to keep in localStorage. */
+export const APP_STATE_KEYS = [
+  "settings",
+  "subAgents",
+  "skills",
+  "todos",
+  "memory",
+  "knowledge",
+  "knowledgeSources",
+  "customProviders",
+  "currentSessionId",
+] as const;
+
+export type AppStateKey = (typeof APP_STATE_KEYS)[number];
+
+export function isAppStateKey(key: string): key is AppStateKey {
+  return (APP_STATE_KEYS as readonly string[]).includes(key);
+}
+
+export class AppStateRepo {
+  private readonly selectOne: Database.Statement;
+  private readonly selectAll: Database.Statement;
+  private readonly upsert: Database.Statement;
+  private readonly remove: Database.Statement;
+
+  constructor(db: Database.Database) {
+    this.selectOne = db.prepare(`SELECT value FROM app_state WHERE key = ?`);
+    this.selectAll = db.prepare(`SELECT key, value FROM app_state`);
+    this.upsert = db.prepare(
+      `INSERT INTO app_state (key, value, updated_at) VALUES (?, ?, ?)
+       ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
+    );
+    this.remove = db.prepare(`DELETE FROM app_state WHERE key = ?`);
+  }
+
+  get(key: AppStateKey): unknown | undefined {
+    const row = this.selectOne.get(key) as { value: string } | undefined;
+    if (!row) return undefined;
+    try {
+      return JSON.parse(row.value) as unknown;
+    } catch {
+      return undefined;
+    }
+  }
+
+  /** Every stored document as a key → value map (single bounded read at boot). */
+  getAll(): Partial<Record<AppStateKey, unknown>> {
+    const rows = this.selectAll.all() as Array<{ key: string; value: string }>;
+    const out: Partial<Record<AppStateKey, unknown>> = {};
+    for (const row of rows) {
+      if (!isAppStateKey(row.key)) continue;
+      try {
+        out[row.key] = JSON.parse(row.value) as unknown;
+      } catch {
+        // skip corrupted document
+      }
+    }
+    return out;
+  }
+
+  set(key: AppStateKey, value: unknown): void {
+    let json: string;
+    try {
+      json = JSON.stringify(value ?? null);
+    } catch {
+      return;
+    }
+    this.upsert.run(key, json, Date.now());
+  }
+
+  delete(key: AppStateKey): void {
+    this.remove.run(key);
+  }
+}

--- a/curro-ai/src/database/repositories/eventsRepo.ts
+++ b/curro-ai/src/database/repositories/eventsRepo.ts
@@ -1,0 +1,77 @@
+import type Database from "better-sqlite3";
+
+export interface StoredStreamEvent {
+  turn: number;
+  eventId: number;
+  firstEventId: number;
+  event: string;
+  data: Record<string, unknown>;
+  createdAt: number;
+}
+
+/**
+ * Read side of the stream-event log (writes happen in the write queue). Every query
+ * is a clustered-index range scan on (session_id, turn, event_id) — replay speed is
+ * independent of total database size.
+ */
+export class EventsRepo {
+  private readonly selectTurnSince: Database.Statement;
+  private readonly selectLastTurn: Database.Statement;
+  private readonly countBySession: Database.Statement;
+
+  constructor(db: Database.Database) {
+    this.selectTurnSince = db.prepare(
+      `SELECT turn, event_id, first_event_id, event, data, created_at
+       FROM stream_events
+       WHERE session_id = ? AND turn = ? AND event_id > ?
+       ORDER BY event_id ASC`,
+    );
+    this.selectLastTurn = db.prepare(
+      `SELECT MAX(turn) AS turn FROM stream_events WHERE session_id = ?`,
+    );
+    this.countBySession = db.prepare(
+      `SELECT COUNT(*) AS n FROM stream_events WHERE session_id = ?`,
+    );
+  }
+
+  /** Events of one turn after `sinceEventId` (exclusive), in stream order. */
+  listTurnSince(sessionId: string, turn: number, sinceEventId = -1): StoredStreamEvent[] {
+    const rows = this.selectTurnSince.all(sessionId, turn, sinceEventId) as Array<{
+      turn: number;
+      event_id: number;
+      first_event_id: number;
+      event: string;
+      data: string;
+      created_at: number;
+    }>;
+    const out: StoredStreamEvent[] = [];
+    for (const row of rows) {
+      let data: Record<string, unknown> = {};
+      try {
+        data = JSON.parse(row.data) as Record<string, unknown>;
+      } catch {
+        // keep an empty payload rather than dropping the event marker
+      }
+      out.push({
+        turn: row.turn,
+        eventId: row.event_id,
+        firstEventId: row.first_event_id,
+        event: row.event,
+        data,
+        createdAt: row.created_at,
+      });
+    }
+    return out;
+  }
+
+  /** The latest turn number that has any persisted events (0 when none). */
+  lastTurn(sessionId: string): number {
+    const row = this.selectLastTurn.get(sessionId) as { turn: number | null } | undefined;
+    return row?.turn ?? 0;
+  }
+
+  count(sessionId: string): number {
+    const row = this.countBySession.get(sessionId) as { n: number } | undefined;
+    return row?.n ?? 0;
+  }
+}

--- a/curro-ai/src/database/repositories/messagesRepo.ts
+++ b/curro-ai/src/database/repositories/messagesRepo.ts
@@ -1,0 +1,41 @@
+import type Database from "better-sqlite3";
+import type { StoredMessage } from "../../services/sessionStore.js";
+
+/**
+ * Provider-format transcript per session. Bulk writes go through the write queue
+ * (`enqueueMessages`); this repo serves the indexed reads and restart hydration.
+ */
+export class MessagesRepo {
+  private readonly selectBySession: Database.Statement;
+  private readonly countBySession: Database.Statement;
+
+  constructor(db: Database.Database) {
+    this.selectBySession = db.prepare(
+      `SELECT data FROM messages WHERE session_id = ? ORDER BY seq ASC`,
+    );
+    this.countBySession = db.prepare(
+      `SELECT COUNT(*) AS n FROM messages WHERE session_id = ?`,
+    );
+  }
+
+  list(sessionId: string): StoredMessage[] {
+    const rows = this.selectBySession.all(sessionId) as Array<{ data: string }>;
+    const out: StoredMessage[] = [];
+    for (const row of rows) {
+      try {
+        const parsed = JSON.parse(row.data) as StoredMessage;
+        if (parsed && typeof parsed === "object" && typeof parsed.role === "string") {
+          out.push(parsed);
+        }
+      } catch {
+        // Skip unreadable rows rather than failing the whole transcript.
+      }
+    }
+    return out;
+  }
+
+  count(sessionId: string): number {
+    const row = this.countBySession.get(sessionId) as { n: number } | undefined;
+    return row?.n ?? 0;
+  }
+}

--- a/curro-ai/src/database/repositories/sessionsRepo.ts
+++ b/curro-ai/src/database/repositories/sessionsRepo.ts
@@ -1,0 +1,140 @@
+import type Database from "better-sqlite3";
+import { createChatSessionId } from "../ids.js";
+
+export interface SessionRow {
+  id: string;
+  title: string;
+  running: boolean;
+  turnCount: number;
+  lastEventId: number;
+  /** Transcript length, maintained by the write queue — read without COUNT scans. */
+  messageCount: number;
+  createdAt: number;
+  updatedAt: number;
+}
+
+interface RawSessionRow {
+  id: string;
+  title: string;
+  running: number;
+  turn_count: number;
+  last_event_id: number;
+  message_count: number;
+  created_at: number;
+  updated_at: number;
+}
+
+function toSession(row: RawSessionRow): SessionRow {
+  return {
+    id: row.id,
+    title: row.title,
+    running: row.running === 1,
+    turnCount: row.turn_count,
+    lastEventId: row.last_event_id,
+    messageCount: row.message_count,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+/** Chat sessions (20-char alphanumeric ids). All lookups are indexed point reads. */
+export class SessionsRepo {
+  private readonly selectOne: Database.Statement;
+  private readonly selectAll: Database.Statement;
+  private readonly insert: Database.Statement;
+  private readonly updateTitle: Database.Statement;
+  private readonly beginTurn: Database.Statement;
+  private readonly endTurn: Database.Statement;
+  private readonly removeSession: Database.Statement;
+  private readonly removeEvents: Database.Statement;
+  private readonly removeMessages: Database.Statement;
+  private readonly removeSnapshot: Database.Statement;
+  private readonly removeToolCalls: Database.Statement;
+  private readonly removeSubAgentRuns: Database.Statement;
+  private readonly clearRunning: Database.Statement;
+
+  constructor(private readonly db: Database.Database) {
+    this.selectOne = db.prepare(`SELECT * FROM sessions WHERE id = ?`);
+    this.selectAll = db.prepare(`SELECT * FROM sessions ORDER BY updated_at DESC LIMIT ?`);
+    this.insert = db.prepare(
+      `INSERT INTO sessions (id, title, running, turn_count, last_event_id, message_count, created_at, updated_at)
+       VALUES (?, ?, 0, 0, -1, 0, ?, ?)
+       ON CONFLICT(id) DO NOTHING`,
+    );
+    this.updateTitle = db.prepare(`UPDATE sessions SET title = ?, updated_at = ? WHERE id = ?`);
+    this.beginTurn = db.prepare(
+      `UPDATE sessions SET running = 1, turn_count = turn_count + 1, last_event_id = -1, updated_at = ?
+       WHERE id = ?`,
+    );
+    this.endTurn = db.prepare(
+      `UPDATE sessions SET running = 0, last_event_id = ?, updated_at = ? WHERE id = ?`,
+    );
+    this.removeSession = db.prepare(`DELETE FROM sessions WHERE id = ?`);
+    this.removeEvents = db.prepare(`DELETE FROM stream_events WHERE session_id = ?`);
+    this.removeMessages = db.prepare(`DELETE FROM messages WHERE session_id = ?`);
+    this.removeSnapshot = db.prepare(`DELETE FROM session_snapshots WHERE session_id = ?`);
+    this.removeToolCalls = db.prepare(`DELETE FROM tool_calls WHERE session_id = ?`);
+    this.removeSubAgentRuns = db.prepare(`DELETE FROM sub_agent_runs WHERE session_id = ?`);
+    this.clearRunning = db.prepare(`UPDATE sessions SET running = 0 WHERE running = 1`);
+  }
+
+  /** Create a brand-new session with a generated 20-char id. */
+  create(title = ""): SessionRow {
+    const id = createChatSessionId();
+    this.ensure(id, title);
+    return this.get(id)!;
+  }
+
+  /** Idempotently ensure a session row exists (client-generated ids arrive here). */
+  ensure(id: string, title = ""): void {
+    const now = Date.now();
+    this.insert.run(id, title, now, now);
+  }
+
+  get(id: string): SessionRow | undefined {
+    const row = this.selectOne.get(id) as RawSessionRow | undefined;
+    return row ? toSession(row) : undefined;
+  }
+
+  list(limit = 500): SessionRow[] {
+    return (this.selectAll.all(limit) as RawSessionRow[]).map(toSession);
+  }
+
+  rename(id: string, title: string): void {
+    this.updateTitle.run(title, Date.now(), id);
+  }
+
+  /** Mark a new turn as running; returns the turn number just started. */
+  startTurn(id: string, title?: string): number {
+    this.ensure(id, title ?? "");
+    if (title && title.trim().length > 0) {
+      const existing = this.get(id);
+      if (existing && existing.title.trim().length === 0) this.rename(id, title);
+    }
+    this.beginTurn.run(Date.now(), id);
+    return this.get(id)?.turnCount ?? 1;
+  }
+
+  /** Mark the running turn as finished and record the last stream event id. */
+  finishTurn(id: string, lastEventId: number): void {
+    this.endTurn.run(lastEventId, Date.now(), id);
+  }
+
+  /** On boot: no turn can still be running after a restart. */
+  resetRunningFlags(): void {
+    this.clearRunning.run();
+  }
+
+  /** Delete a session and every dependent row. */
+  delete(id: string): void {
+    const tx = this.db.transaction(() => {
+      this.removeEvents.run(id);
+      this.removeMessages.run(id);
+      this.removeSnapshot.run(id);
+      this.removeToolCalls.run(id);
+      this.removeSubAgentRuns.run(id);
+      this.removeSession.run(id);
+    });
+    tx();
+  }
+}

--- a/curro-ai/src/database/repositories/snapshotsRepo.ts
+++ b/curro-ai/src/database/repositories/snapshotsRepo.ts
@@ -1,0 +1,45 @@
+import type Database from "better-sqlite3";
+
+/**
+ * UI-shaped conversation snapshots — the JSON the frontend renders for a session
+ * (messages with tool chips, sub-agent runs, plan/question blocks...). One document
+ * per session, replaced wholesale; reads/writes are point lookups on the PK.
+ */
+export class SnapshotsRepo {
+  private readonly selectOne: Database.Statement;
+  private readonly upsert: Database.Statement;
+  private readonly remove: Database.Statement;
+
+  constructor(db: Database.Database) {
+    this.selectOne = db.prepare(`SELECT data FROM session_snapshots WHERE session_id = ?`);
+    this.upsert = db.prepare(
+      `INSERT INTO session_snapshots (session_id, data, updated_at) VALUES (?, ?, ?)
+       ON CONFLICT(session_id) DO UPDATE SET data = excluded.data, updated_at = excluded.updated_at`,
+    );
+    this.remove = db.prepare(`DELETE FROM session_snapshots WHERE session_id = ?`);
+  }
+
+  get(sessionId: string): unknown | null {
+    const row = this.selectOne.get(sessionId) as { data: string } | undefined;
+    if (!row) return null;
+    try {
+      return JSON.parse(row.data) as unknown;
+    } catch {
+      return null;
+    }
+  }
+
+  set(sessionId: string, snapshot: unknown): void {
+    let json: string;
+    try {
+      json = JSON.stringify(snapshot ?? null);
+    } catch {
+      return;
+    }
+    this.upsert.run(sessionId, json, Date.now());
+  }
+
+  delete(sessionId: string): void {
+    this.remove.run(sessionId);
+  }
+}

--- a/curro-ai/src/database/repositories/subAgentRunsRepo.ts
+++ b/curro-ai/src/database/repositories/subAgentRunsRepo.ts
@@ -1,0 +1,76 @@
+import type Database from "better-sqlite3";
+
+export interface SubAgentRunRow {
+  id: string;
+  sessionId: string;
+  turn: number;
+  toolCallId: string;
+  agent: string;
+  task: string;
+  background: boolean;
+  status: "running" | "completed" | "failed" | "aborted";
+  output: string;
+  error: string | null;
+  outputFile: string | null;
+  startedAt: number;
+  finishedAt: number | null;
+}
+
+/**
+ * Read side for sub-agent run records (10-char session ids). Rows are written by the
+ * write queue as `sub_agent_start` / `sub_agent_done` events flow through it.
+ */
+export class SubAgentRunsRepo {
+  private readonly selectBySession: Database.Statement;
+  private readonly selectOne: Database.Statement;
+
+  constructor(db: Database.Database) {
+    this.selectBySession = db.prepare(
+      `SELECT * FROM sub_agent_runs WHERE session_id = ? ORDER BY started_at ASC`,
+    );
+    this.selectOne = db.prepare(`SELECT * FROM sub_agent_runs WHERE id = ?`);
+  }
+
+  listBySession(sessionId: string): SubAgentRunRow[] {
+    return (this.selectBySession.all(sessionId) as RawRow[]).map(toRow);
+  }
+
+  get(id: string): SubAgentRunRow | undefined {
+    const row = this.selectOne.get(id) as RawRow | undefined;
+    return row ? toRow(row) : undefined;
+  }
+}
+
+interface RawRow {
+  id: string;
+  session_id: string;
+  turn: number;
+  tool_call_id: string;
+  agent: string;
+  task: string;
+  background: number;
+  status: string;
+  output: string;
+  error: string | null;
+  output_file: string | null;
+  started_at: number;
+  finished_at: number | null;
+}
+
+function toRow(row: RawRow): SubAgentRunRow {
+  return {
+    id: row.id,
+    sessionId: row.session_id,
+    turn: row.turn,
+    toolCallId: row.tool_call_id,
+    agent: row.agent,
+    task: row.task,
+    background: row.background === 1,
+    status: (row.status as SubAgentRunRow["status"]) ?? "running",
+    output: row.output,
+    error: row.error,
+    outputFile: row.output_file,
+    startedAt: row.started_at,
+    finishedAt: row.finished_at,
+  };
+}

--- a/curro-ai/src/database/schema.ts
+++ b/curro-ai/src/database/schema.ts
@@ -1,0 +1,131 @@
+import type Database from "better-sqlite3";
+
+/**
+ * Database schema.
+ *
+ * Design notes for "never gets slower as the database grows":
+ * - Every read path is a point lookup or an indexed range scan — there is not a single
+ *   full-table scan anywhere in the repositories.
+ * - `stream_events` is a WITHOUT ROWID table clustered on (session_id, turn, event_id):
+ *   appends land at the end of a session's cluster and replay reads are one contiguous
+ *   range scan, regardless of how many other sessions/tokens exist.
+ * - Token/reasoning deltas are coalesced by the write queue before insertion, so a
+ *   100k tokens/second stream produces a handful of rows per flush, not 100k rows.
+ * - Schema version is tracked in `user_version` for forward migrations.
+ */
+
+const SCHEMA_VERSION = 1;
+
+const DDL = `
+CREATE TABLE IF NOT EXISTS sessions (
+  id            TEXT PRIMARY KEY,            -- 20-char alphanumeric chat session id
+  title         TEXT NOT NULL DEFAULT '',
+  running       INTEGER NOT NULL DEFAULT 0,
+  turn_count    INTEGER NOT NULL DEFAULT 0,  -- number of agent turns executed
+  last_event_id INTEGER NOT NULL DEFAULT -1, -- last stream event id of the latest turn
+  message_count INTEGER NOT NULL DEFAULT 0,  -- maintained by the write queue (no COUNT scans)
+  created_at    INTEGER NOT NULL,
+  updated_at    INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_sessions_updated ON sessions (updated_at DESC);
+
+-- Provider-format transcript (OpenAI wire shape), authoritative model context per session.
+CREATE TABLE IF NOT EXISTS messages (
+  session_id TEXT NOT NULL,
+  seq        INTEGER NOT NULL,
+  role       TEXT NOT NULL,
+  data       TEXT NOT NULL,                  -- full StoredMessage JSON
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (session_id, seq)
+) WITHOUT ROWID;
+
+-- Full stream event log: every SSE event of the main agent AND all sub-agents
+-- (tokens, reasoning, tool calls, tool results, statuses...). Consecutive token /
+-- reasoning deltas are coalesced into single rows by the write queue.
+CREATE TABLE IF NOT EXISTS stream_events (
+  session_id     TEXT NOT NULL,
+  turn           INTEGER NOT NULL,
+  event_id       INTEGER NOT NULL,           -- LAST event id covered by this row
+  first_event_id INTEGER NOT NULL,           -- FIRST event id covered (== event_id unless coalesced)
+  event          TEXT NOT NULL,
+  data           TEXT NOT NULL,
+  created_at     INTEGER NOT NULL,
+  PRIMARY KEY (session_id, turn, event_id)
+) WITHOUT ROWID;
+
+-- One row per sub-agent invocation; 10-char alphanumeric run/session id.
+CREATE TABLE IF NOT EXISTS sub_agent_runs (
+  id           TEXT PRIMARY KEY,             -- 10-char sub-agent session id
+  session_id   TEXT NOT NULL,
+  turn         INTEGER NOT NULL DEFAULT 0,
+  tool_call_id TEXT NOT NULL DEFAULT '',
+  agent        TEXT NOT NULL DEFAULT '',
+  task         TEXT NOT NULL DEFAULT '',
+  background   INTEGER NOT NULL DEFAULT 0,
+  status       TEXT NOT NULL DEFAULT 'running', -- running | completed | failed | aborted
+  output       TEXT NOT NULL DEFAULT '',
+  error        TEXT,
+  output_file  TEXT,
+  started_at   INTEGER NOT NULL,
+  finished_at  INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS idx_sub_agent_runs_session ON sub_agent_runs (session_id, started_at);
+
+-- Structured record of every tool call + result (main agent and sub-agents).
+CREATE TABLE IF NOT EXISTS tool_calls (
+  session_id       TEXT NOT NULL,
+  tool_call_id     TEXT NOT NULL,
+  sub_agent_run_id TEXT,                     -- NULL for main-agent tool calls
+  name             TEXT NOT NULL DEFAULT '',
+  label            TEXT,
+  args             TEXT,
+  ok               INTEGER,                  -- NULL until the result arrives
+  result           TEXT,
+  created_at       INTEGER NOT NULL,
+  finished_at      INTEGER,
+  PRIMARY KEY (session_id, tool_call_id)
+) WITHOUT ROWID;
+
+-- UI-shaped conversation snapshots (what the frontend renders), one JSON doc per session.
+CREATE TABLE IF NOT EXISTS session_snapshots (
+  session_id TEXT PRIMARY KEY,
+  data       TEXT NOT NULL,
+  updated_at INTEGER NOT NULL
+) WITHOUT ROWID;
+
+-- Application state documents: settings (incl. API keys), custom sub-agent definitions,
+-- skill files, memory files, knowledge files, todos, custom providers, UI selections...
+CREATE TABLE IF NOT EXISTS app_state (
+  key        TEXT PRIMARY KEY,
+  value      TEXT NOT NULL,
+  updated_at INTEGER NOT NULL
+) WITHOUT ROWID;
+`;
+
+/** Create all tables/indexes (idempotent) and stamp the schema version. */
+export function applySchema(db: Database.Database): void {
+  const current = Number(db.pragma("user_version", { simple: true }));
+  db.exec(DDL);
+
+  // Additive migrations for databases created by earlier schema revisions.
+  ensureColumn(db, "sessions", "message_count", "INTEGER NOT NULL DEFAULT 0");
+
+  if (current < SCHEMA_VERSION) {
+    db.pragma(`user_version = ${SCHEMA_VERSION}`);
+  }
+}
+
+/** Add a column to an existing table when it is missing (idempotent, additive-only). */
+function ensureColumn(
+  db: Database.Database,
+  table: string,
+  column: string,
+  definition: string,
+): void {
+  const columns = db.pragma(`table_info(${table})`) as Array<{ name: string }>;
+  if (!columns.some((c) => c.name === column)) {
+    db.exec(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition}`);
+  }
+}

--- a/curro-ai/src/database/writeQueue.ts
+++ b/curro-ai/src/database/writeQueue.ts
@@ -1,0 +1,412 @@
+import type Database from "better-sqlite3";
+
+/**
+ * DatabaseWriteQueue — the ONLY path through which streaming-rate data reaches SQLite.
+ *
+ * Why it exists: the agent can emit 10,000-100,000+ tokens/second (and dozens of
+ * sub-agents can stream concurrently). Writing each delta synchronously would block
+ * the event loop and freeze the app + device. Instead:
+ *
+ * 1. `enqueueEvent()` is O(1) and allocation-light: it appends to an in-memory list.
+ *    No JSON serialization, no SQLite call, no disk I/O on the hot path.
+ * 2. Consecutive token/reasoning deltas of the same stream are COALESCED in memory:
+ *    a whole flush window of a 100k tok/s stream collapses into a single row whose
+ *    `value` is the concatenated text and whose (first_event_id, event_id) records
+ *    the covered range. Ordering is preserved: any structural event (tool call,
+ *    sub-agent boundary, ...) closes the open coalescing buckets for that session.
+ * 3. A timer flushes every FLUSH_INTERVAL_MS inside ONE WAL transaction using
+ *    prepared statements — sequential appends, no fsync on the caller's path
+ *    (synchronous=NORMAL). Large backlogs are written in chunks with event-loop
+ *    yields between chunks so the server never stalls, even under a burst.
+ *
+ * The same flush also derives the structured `tool_calls` and `sub_agent_runs` rows
+ * from the event stream, so structured records cost nothing on the hot path either.
+ */
+
+/** Delta events that may be coalesced into a single row per flush window. */
+const COALESCABLE = new Set(["token", "reasoning", "sub_agent_token", "sub_agent_reasoning"]);
+
+const FLUSH_INTERVAL_MS = 200;
+/** Force an immediate (next-tick) flush when this many rows are pending. */
+const HIGH_WATER_ROWS = 8_000;
+/** Max rows written per transaction chunk before yielding back to the event loop. */
+const CHUNK_ROWS = 2_000;
+
+interface PendingEvent {
+  sessionId: string;
+  turn: number;
+  /** Last event id covered by this row. */
+  eventId: number;
+  /** First event id covered by this row (== eventId unless coalesced). */
+  firstEventId: number;
+  event: string;
+  /** For coalesced rows the `value` field is accumulated separately in `text`. */
+  data: Record<string, unknown>;
+  /** Accumulated delta text for coalescable events. */
+  text?: string;
+  createdAt: number;
+}
+
+interface PendingMessages {
+  sessionId: string;
+  messages: unknown[];
+  updatedAt: number;
+}
+
+export class DatabaseWriteQueue {
+  private pendingEvents: PendingEvent[] = [];
+  /**
+   * Open coalescing buckets indexed per session, so closing one session's buckets on a
+   * structural event is a single Map delete instead of a scan over every live stream.
+   * Inner key: "<event> <subAgentToolId>".
+   */
+  private coalesceHeads = new Map<string, Map<string, PendingEvent>>();
+  private pendingMessages = new Map<string, PendingMessages>();
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private flushing = false;
+  private closed = false;
+
+  private readonly insertEvent: Database.Statement;
+  private readonly upsertToolCall: Database.Statement;
+  private readonly finishToolCall: Database.Statement;
+  private readonly insertSubAgentRun: Database.Statement;
+  private readonly finishSubAgentRun: Database.Statement;
+  private readonly deleteMessages: Database.Statement;
+  private readonly insertMessage: Database.Statement;
+  private readonly updateMessageCount: Database.Statement;
+
+  constructor(private readonly db: Database.Database) {
+    this.insertEvent = db.prepare(
+      `INSERT OR REPLACE INTO stream_events
+         (session_id, turn, event_id, first_event_id, event, data, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    );
+    this.upsertToolCall = db.prepare(
+      `INSERT INTO tool_calls (session_id, tool_call_id, sub_agent_run_id, name, label, args, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(session_id, tool_call_id) DO UPDATE SET
+         name = excluded.name, label = excluded.label, args = excluded.args,
+         sub_agent_run_id = COALESCE(excluded.sub_agent_run_id, tool_calls.sub_agent_run_id)`,
+    );
+    this.finishToolCall = db.prepare(
+      `INSERT INTO tool_calls (session_id, tool_call_id, sub_agent_run_id, name, label, ok, result, created_at, finished_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(session_id, tool_call_id) DO UPDATE SET
+         ok = excluded.ok, result = excluded.result, finished_at = excluded.finished_at,
+         name = CASE WHEN excluded.name != '' THEN excluded.name ELSE tool_calls.name END,
+         label = COALESCE(excluded.label, tool_calls.label)`,
+    );
+    this.insertSubAgentRun = db.prepare(
+      `INSERT INTO sub_agent_runs (id, session_id, turn, tool_call_id, agent, task, background, status, output_file, started_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, 'running', ?, ?)
+       ON CONFLICT(id) DO UPDATE SET
+         agent = excluded.agent, task = excluded.task, background = excluded.background,
+         tool_call_id = excluded.tool_call_id,
+         output_file = COALESCE(excluded.output_file, sub_agent_runs.output_file)`,
+    );
+    this.finishSubAgentRun = db.prepare(
+      `UPDATE sub_agent_runs SET status = ?, output = ?, error = ?, finished_at = ? WHERE id = ?`,
+    );
+    this.deleteMessages = db.prepare(`DELETE FROM messages WHERE session_id = ?`);
+    this.insertMessage = db.prepare(
+      `INSERT INTO messages (session_id, seq, role, data, created_at) VALUES (?, ?, ?, ?, ?)`,
+    );
+    this.updateMessageCount = db.prepare(
+      `UPDATE sessions SET message_count = ? WHERE id = ?`,
+    );
+  }
+
+  /** Rows waiting to be flushed (for observability/tests). */
+  get pendingCount(): number {
+    return this.pendingEvents.length + this.pendingMessages.size;
+  }
+
+  /**
+   * Record one SSE event. O(1), no serialization, no I/O — safe at any token rate.
+   * Consecutive deltas of the same stream are merged in place.
+   */
+  enqueueEvent(
+    sessionId: string,
+    turn: number,
+    eventId: number,
+    event: string,
+    data: Record<string, unknown>,
+  ): void {
+    if (this.closed) return;
+
+    if (COALESCABLE.has(event)) {
+      // Sub-agent deltas coalesce per sub-agent (keyed by the parent tool-call id).
+      const subId = typeof data.id === "string" ? (data.id as string) : "";
+      const key = `${event} ${subId}`;
+      const sessionHeads = this.coalesceHeads.get(sessionId);
+      const head = sessionHeads?.get(key);
+      const value = typeof data.value === "string" ? (data.value as string) : "";
+      if (head && head.turn === turn) {
+        head.text! += value;
+        head.eventId = eventId;
+        return;
+      }
+      const row: PendingEvent = {
+        sessionId,
+        turn,
+        eventId,
+        firstEventId: eventId,
+        event,
+        data,
+        text: value,
+        createdAt: Date.now(),
+      };
+      if (sessionHeads) sessionHeads.set(key, row);
+      else this.coalesceHeads.set(sessionId, new Map([[key, row]]));
+      this.pendingEvents.push(row);
+      this.schedule();
+      return;
+    }
+
+    // A structural event closes every open delta bucket for this session so the
+    // persisted order stays faithful to what actually streamed.
+    this.coalesceHeads.delete(sessionId);
+
+    this.pendingEvents.push({
+      sessionId,
+      turn,
+      eventId,
+      firstEventId: eventId,
+      event,
+      data,
+      createdAt: Date.now(),
+    });
+    this.schedule();
+  }
+
+  /** Queue a full transcript replacement for a session (last write wins). */
+  enqueueMessages(sessionId: string, messages: unknown[]): void {
+    if (this.closed) return;
+    this.pendingMessages.set(sessionId, {
+      sessionId,
+      messages: messages.slice(),
+      updatedAt: Date.now(),
+    });
+    this.schedule();
+  }
+
+  /** Flush everything synchronously (shutdown path). */
+  flushSync(): void {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    while (this.pendingEvents.length > 0 || this.pendingMessages.size > 0) {
+      this.flushChunk(Number.MAX_SAFE_INTEGER);
+    }
+  }
+
+  /** Stop accepting writes and flush the backlog. */
+  close(): void {
+    this.flushSync();
+    this.closed = true;
+  }
+
+  private schedule(): void {
+    if (this.pendingEvents.length >= HIGH_WATER_ROWS) {
+      if (this.timer) {
+        clearTimeout(this.timer);
+        this.timer = null;
+      }
+      setImmediate(() => this.flushAsync());
+      return;
+    }
+    if (this.timer || this.flushing) return;
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      this.flushAsync();
+    }, FLUSH_INTERVAL_MS);
+    // Never keep the process alive just for a pending flush.
+    if (typeof this.timer.unref === "function") this.timer.unref();
+  }
+
+  /** Flush in bounded chunks, yielding to the event loop between chunks. */
+  private flushAsync(): void {
+    if (this.flushing || this.closed) return;
+    this.flushing = true;
+    const step = (): void => {
+      try {
+        this.flushChunk(CHUNK_ROWS);
+      } catch (error) {
+        // Persistence must never take down streaming; drop the failed chunk and log.
+        // eslint-disable-next-line no-console
+        console.error("[curro-db] flush failed:", error);
+      }
+      if (this.pendingEvents.length > 0 || this.pendingMessages.size > 0) {
+        setImmediate(step);
+        return;
+      }
+      // Anything enqueued after this point schedules its own timer via enqueue*().
+      this.flushing = false;
+    };
+    step();
+  }
+
+  private flushChunk(maxRows: number): void {
+    const events = this.pendingEvents.splice(0, maxRows);
+    // Any head that was taken out of pending must stop accumulating (O(rows + heads)).
+    if (this.coalesceHeads.size > 0 && events.length > 0) {
+      const taken = new Set<PendingEvent>(events);
+      for (const [sessionId, sessionHeads] of this.coalesceHeads) {
+        for (const [key, head] of sessionHeads) {
+          if (taken.has(head)) sessionHeads.delete(key);
+        }
+        if (sessionHeads.size === 0) this.coalesceHeads.delete(sessionId);
+      }
+    }
+
+    const messages = Array.from(this.pendingMessages.values());
+    this.pendingMessages.clear();
+
+    if (events.length === 0 && messages.length === 0) return;
+
+    const write = this.db.transaction(() => {
+      for (const row of events) {
+        const payload =
+          row.text !== undefined ? { ...row.data, value: row.text } : row.data;
+        let json: string;
+        try {
+          json = JSON.stringify(payload);
+        } catch {
+          json = "{}";
+        }
+        this.insertEvent.run(
+          row.sessionId,
+          row.turn,
+          row.eventId,
+          row.firstEventId,
+          row.event,
+          json,
+          row.createdAt,
+        );
+        this.deriveStructured(row);
+      }
+
+      for (const entry of messages) {
+        this.deleteMessages.run(entry.sessionId);
+        this.updateMessageCount.run(entry.messages.length, entry.sessionId);
+        for (let seq = 0; seq < entry.messages.length; seq += 1) {
+          const message = entry.messages[seq] as Record<string, unknown> | null;
+          if (!message || typeof message !== "object") continue;
+          let json: string;
+          try {
+            json = JSON.stringify(message);
+          } catch {
+            continue;
+          }
+          this.insertMessage.run(
+            entry.sessionId,
+            seq,
+            typeof message.role === "string" ? (message.role as string) : "unknown",
+            json,
+            entry.updatedAt,
+          );
+        }
+      }
+    });
+    write();
+  }
+
+  /** Derive structured tool_calls / sub_agent_runs rows from the raw event stream. */
+  private deriveStructured(row: PendingEvent): void {
+    const data = row.data;
+    const str = (v: unknown): string => (typeof v === "string" ? v : "");
+    const json = (v: unknown): string | null => {
+      if (v === undefined || v === null) return null;
+      try {
+        return typeof v === "string" ? v : JSON.stringify(v);
+      } catch {
+        return null;
+      }
+    };
+
+    switch (row.event) {
+      case "tool_call":
+        this.upsertToolCall.run(
+          row.sessionId,
+          str(data.id) || `tool_${row.turn}_${row.eventId}`,
+          null,
+          str(data.name),
+          str(data.label) || null,
+          json(data.args),
+          row.createdAt,
+        );
+        break;
+      case "tool_result":
+        this.finishToolCall.run(
+          row.sessionId,
+          str(data.id) || `tool_${row.turn}_${row.eventId}`,
+          null,
+          str(data.name),
+          str(data.label) || null,
+          data.ok === false ? 0 : 1,
+          json(data.result),
+          row.createdAt,
+          row.createdAt,
+        );
+        break;
+      case "sub_agent_tool_call":
+        this.upsertToolCall.run(
+          row.sessionId,
+          str(data.tool_id) || `subtool_${row.turn}_${row.eventId}`,
+          str(data.sub_session_id) || null,
+          str(data.name),
+          str(data.label) || null,
+          json(data.args),
+          row.createdAt,
+        );
+        break;
+      case "sub_agent_tool_result":
+        this.finishToolCall.run(
+          row.sessionId,
+          str(data.tool_id) || `subtool_${row.turn}_${row.eventId}`,
+          str(data.sub_session_id) || null,
+          str(data.name),
+          str(data.label) || null,
+          data.ok === false ? 0 : 1,
+          json(data.result),
+          row.createdAt,
+          row.createdAt,
+        );
+        break;
+      case "sub_agent_start":
+      case "sub_agent_background_started": {
+        const runId = str(data.sub_session_id);
+        if (!runId) break;
+        this.insertSubAgentRun.run(
+          runId,
+          row.sessionId,
+          row.turn,
+          str(data.id),
+          str(data.agent),
+          str(data.task),
+          row.event === "sub_agent_background_started" || data.background === true ? 1 : 0,
+          str(data.output_file) || null,
+          row.createdAt,
+        );
+        break;
+      }
+      case "sub_agent_done": {
+        const runId = str(data.sub_session_id);
+        if (!runId) break;
+        const status =
+          data.aborted === true ? "aborted" : data.ok === true ? "completed" : "failed";
+        this.finishSubAgentRun.run(
+          status,
+          str(data.output),
+          str(data.error) || null,
+          row.createdAt,
+          runId,
+        );
+        break;
+      }
+      default:
+        break;
+    }
+  }
+}

--- a/curro-ai/src/index.ts
+++ b/curro-ai/src/index.ts
@@ -11,9 +11,14 @@ import { buildChatRouter } from "./api/chat.js";
 import { buildProviderRouter } from "./api/providers.js";
 import { buildFilesRouter } from "./api/files.js";
 import { buildScrapeRouter } from "./api/scrape.js";
+import { buildStateRouter, buildSessionsRouter } from "./api/state.js";
+import { CurroDatabase } from "./database/index.js";
 
 function main(): void {
   ensureWorkspace();
+
+  // The SQLite database (workspace/.curro/curro.db) is created automatically on boot.
+  const db = CurroDatabase.open(config.workspaceRoot);
 
   const providers = createProviderRegistry();
   const tools = createToolRegistry();
@@ -39,13 +44,17 @@ function main(): void {
       providers: providers.list().map((p) => p.id),
       tools: tools.schemas.map((s) => s.function.name),
       max_iterations: config.maxIterations,
+      database: db.path,
+      sqlite_version: db.version,
     });
   });
 
   app.use("/api/providers", buildProviderRouter(providers));
-  app.use("/api/chat", buildChatRouter(agent, store, config, planApprovals, askQuestions));
+  app.use("/api/chat", buildChatRouter(agent, store, config, planApprovals, askQuestions, db));
   app.use("/api/files", buildFilesRouter(config));
   app.use("/api/scrape", buildScrapeRouter(config));
+  app.use("/api/state", buildStateRouter(db));
+  app.use("/api/sessions", buildSessionsRouter(db));
 
   const server = app.listen(config.port, () => {
     // eslint-disable-next-line no-console
@@ -55,6 +64,8 @@ function main(): void {
   });
 
   const shutdown = () => {
+    // Flush the write queue and checkpoint the WAL before exiting.
+    db.close();
     server.close(() => process.exit(0));
     setTimeout(() => process.exit(0), 5000).unref();
   };

--- a/curro-ai/src/services/eventBuffer.ts
+++ b/curro-ai/src/services/eventBuffer.ts
@@ -14,9 +14,24 @@ export class SessionEventBuffer {
   private done = false;
   private waiters: Array<() => void> = [];
 
+  /**
+   * @param sink Optional persistence hook invoked for every appended event (the
+   *             database write queue). It must be O(1) and non-throwing on the hot
+   *             path — a failure to persist must never break live streaming.
+   */
+  constructor(private readonly sink?: (id: number, event: string, data: Record<string, unknown>) => void) {}
+
   append(event: string, data: Record<string, unknown>): number {
     const id = this.events.length;
-    this.events.push({ id, event, data: { _event_id: id, ...data } });
+    const payload = { _event_id: id, ...data };
+    this.events.push({ id, event, data: payload });
+    if (this.sink) {
+      try {
+        this.sink(id, event, payload);
+      } catch {
+        // Persistence must never break live streaming.
+      }
+    }
     this.notify();
     return id;
   }

--- a/frontend-main/src/app/App.tsx
+++ b/frontend-main/src/app/App.tsx
@@ -15,28 +15,59 @@ import { PreviewPanel } from "@/components/overlays/PreviewPanel";
 import { useStore } from "@/store/useStore";
 import { useChatStream, useConnectionWatch } from "@/hooks/useChatStream";
 import { fetchProviders } from "@/lib/api";
+import {
+  bootstrapFromBackend,
+  loadConversationIfNeeded,
+  startStatePersistence,
+} from "@/lib/statePersistence";
 
 export function App() {
   const section = useStore((s) => s.section);
+  const currentId = useStore((s) => s.currentId);
+  const hydrated = useStore((s) => s.hydrated);
   const setProviders = useStore((s) => s.setProviders);
-  const ensureConversation = useStore((s) => s.ensureConversation);
   const { send, resume, stop } = useChatStream();
-  const resumedRef = useRef(false);
+  const bootedRef = useRef(false);
 
   useConnectionWatch();
 
+  // Boot: hydrate the runtime store from the backend SQLite database, start the
+  // change-sync bridge, then re-attach to any run the backend is still executing —
+  // a page refresh loses nothing and reconnects to the live stream immediately.
   useEffect(() => {
-    ensureConversation();
-    fetchProviders().then(setProviders).catch(() => {});
-  }, [ensureConversation, setProviders]);
+    if (bootedRef.current) return;
+    bootedRef.current = true;
 
-  // Re-attach to a run the backend may still be executing (survives refresh/close/reconnect).
+    fetchProviders().then(setProviders).catch(() => {});
+
+    void (async () => {
+      const payload = await bootstrapFromBackend();
+      startStatePersistence();
+
+      const store = useStore.getState();
+      const activeId = store.currentId;
+      if (activeId) await loadConversationIfNeeded(activeId);
+      useStore.getState().ensureConversation();
+
+      // Re-attach to a still-running stream (survives refresh/close/reconnect).
+      const running = payload.sessions.find((s) => s.running);
+      if (running) {
+        await loadConversationIfNeeded(running.id);
+        void resume({
+          chatId: running.id,
+          assistantId: "", // rebuilt by resume(): a fresh placeholder receives the replay
+          lastEventId: -1,
+          startedAt: Date.now(),
+        });
+      }
+    })();
+  }, [resume, setProviders]);
+
+  // Lazily pull a conversation's stored snapshot from the database when it is opened.
   useEffect(() => {
-    if (resumedRef.current) return;
-    resumedRef.current = true;
-    const run = useStore.getState().activeRun;
-    if (run) void resume(run);
-  }, [resume]);
+    if (!hydrated || !currentId) return;
+    void loadConversationIfNeeded(currentId);
+  }, [hydrated, currentId]);
 
   return (
     <div className="flex h-dvh w-full overflow-hidden bg-[var(--bg)] text-[var(--fg)]">

--- a/frontend-main/src/app/api/routes.ts
+++ b/frontend-main/src/app/api/routes.ts
@@ -7,7 +7,7 @@
  * `frontend-2` used, expressed as a typed registry for the Vite/React app.
  */
 
-export type HttpMethod = "GET" | "POST";
+export type HttpMethod = "GET" | "POST" | "PUT" | "DELETE";
 
 export interface ApiRoute {
   /** Logical name used by the client (e.g. `chat.stream`). */
@@ -85,6 +85,36 @@ export const API_ROUTES = {
     method: "POST",
     path: "/api/scrape",
     description: "Fetch a URL's content via the built-in scraper for the URL→knowledge flow.",
+  },
+  stateGet: {
+    name: "state.get",
+    method: "GET",
+    path: "/api/state",
+    description: "Load the full application state (settings, skills, memory, sessions…) from SQLite.",
+  },
+  stateSet: {
+    name: "state.set",
+    method: "POST",
+    path: "/api/state/:key",
+    description: "Persist one application-state document into the backend SQLite database.",
+  },
+  sessionGet: {
+    name: "session.get",
+    method: "GET",
+    path: "/api/sessions/:id",
+    description: "Load one session's snapshot + transcript from the backend SQLite database.",
+  },
+  sessionSave: {
+    name: "session.save",
+    method: "POST",
+    path: "/api/sessions/:id",
+    description: "Upsert a session (title and/or UI conversation snapshot) into SQLite.",
+  },
+  sessionDelete: {
+    name: "session.delete",
+    method: "DELETE",
+    path: "/api/sessions/:id",
+    description: "Delete a session and all of its stored data from SQLite.",
   },
 } as const satisfies Record<string, ApiRoute>;
 

--- a/frontend-main/src/components/chat/ChatPanel.tsx
+++ b/frontend-main/src/components/chat/ChatPanel.tsx
@@ -25,7 +25,8 @@ export function ChatPanel({ onSend }: { onSend: (text: string) => void }) {
   const recents = useMemo(
     () =>
       conversations
-        .filter((c) => c.id !== currentId && c.messages.length > 0)
+        // Unloaded stubs from the database report their size via messageCount.
+        .filter((c) => c.id !== currentId && Math.max(c.messages.length, c.messageCount ?? 0) > 0)
         .slice(0, 5),
     [conversations, currentId],
   );
@@ -84,7 +85,8 @@ export function ChatPanel({ onSend }: { onSend: (text: string) => void }) {
                         {c.title}
                       </span>
                       <span className="block text-xs text-[var(--subtle)]">
-                        {c.messages.length} message{c.messages.length === 1 ? "" : "s"} ·{" "}
+                        {Math.max(c.messages.length, c.messageCount ?? 0)} message
+                        {Math.max(c.messages.length, c.messageCount ?? 0) === 1 ? "" : "s"} ·{" "}
                         {timeAgo(c.updatedAt)}
                       </span>
                     </span>

--- a/frontend-main/src/hooks/useChatStream.ts
+++ b/frontend-main/src/hooks/useChatStream.ts
@@ -197,18 +197,45 @@ export function useChatStream(onFilesChanged?: () => void) {
     [drive],
   );
 
-  /** Re-attach to a run the backend is still executing (after a refresh/reconnect). */
+  /**
+   * Re-attach to a run the backend is still executing (after a refresh/reconnect).
+   * The stream replays from event 0, so the assistant message is rebuilt in full —
+   * after a refresh a fresh placeholder message is created to receive the replay.
+   */
   const resume = useCallback(
     async (run: ActiveRun) => {
       if (runningRef.current) return;
       const store = useStore.getState();
       const conv = store.conversations.find((c) => c.id === run.chatId);
-      const msg = conv?.messages.find((m) => m.id === run.assistantId);
-      if (!conv || !msg) {
+      if (!conv) {
         store.setActiveRun(null);
         return;
       }
-      await drive({ convId: run.chatId, assistantId: run.assistantId, resume: true });
+      let assistantId = run.assistantId;
+      const msg = conv.messages.find((m) => m.id === assistantId);
+      if (!msg) {
+        // Post-refresh: runtime state was rebuilt from the database snapshot. If the
+        // snapshot already contains the in-flight (partial) assistant message, REUSE it
+        // — the replay resets and refills it in place, so nothing is duplicated. Only
+        // create a fresh placeholder when the thread doesn't end with an assistant.
+        const last = conv.messages[conv.messages.length - 1];
+        if (last && last.role === "assistant") {
+          assistantId = last.id;
+          store.updateMessage(run.chatId, assistantId, { streaming: true });
+        } else {
+          assistantId = uid("msg");
+          store.addMessage(run.chatId, {
+            id: assistantId,
+            role: "assistant",
+            content: "",
+            streaming: true,
+            tools: [],
+            createdAt: Date.now(),
+          });
+        }
+        store.setActiveRun({ ...run, assistantId });
+      }
+      await drive({ convId: run.chatId, assistantId, resume: true });
     },
     [drive],
   );

--- a/frontend-main/src/lib/api.ts
+++ b/frontend-main/src/lib/api.ts
@@ -29,7 +29,8 @@ export interface ScrapeUrlOptions {
   curl?: string;
 }
 
-async function requestJson<T>(url: string, init?: RequestInit, signal?: AbortSignal): Promise<T> {
+/** Shared JSON request helper (also used by the SQLite state client in `backendState.ts`). */
+export async function requestJson<T>(url: string, init?: RequestInit, signal?: AbortSignal): Promise<T> {
   const res = await resilientFetch(url, { cache: "no-store", ...init }, { signal });
   const data = await res.json().catch(() => ({}));
   if (!res.ok) {

--- a/frontend-main/src/lib/backendState.ts
+++ b/frontend-main/src/lib/backendState.ts
@@ -1,0 +1,123 @@
+import { API_ROUTES, routeUrl } from "@/app/api/routes";
+import { requestJson } from "@/lib/api";
+import { resilientFetch } from "@/lib/net";
+import type { Conversation } from "@/types";
+
+/**
+ * Client for the backend's SQLite-backed state APIs. The browser keeps NOTHING in
+ * localStorage (or any other browser storage): on boot the app hydrates from
+ * `GET /api/state`, and every change is written back to the database through
+ * these calls. Chat/session data lives only in runtime memory plus SQLite.
+ */
+
+/** One session row from the database's session list. */
+export interface BackendSessionMeta {
+  id: string;
+  title: string;
+  running: boolean;
+  createdAt: number;
+  updatedAt: number;
+  messageCount: number;
+}
+
+/** Payload of GET /api/state — everything needed to boot in one round trip. */
+export interface BackendBootPayload {
+  sqlite_version?: string;
+  state: Record<string, unknown>;
+  sessions: BackendSessionMeta[];
+}
+
+/** Payload of GET /api/sessions/:id. */
+export interface BackendSessionDetail {
+  session: { id: string; title: string; running: boolean; createdAt: number; updatedAt: number };
+  snapshot: unknown;
+  transcript: Array<{ role: string; content?: unknown }>;
+}
+
+/** Load the entire application state from the backend database (boot hydration). */
+export async function fetchBootState(): Promise<BackendBootPayload> {
+  const data = await requestJson<Partial<BackendBootPayload>>(routeUrl(API_ROUTES.stateGet));
+  return {
+    sqlite_version: data.sqlite_version,
+    state: data.state && typeof data.state === "object" ? data.state : {},
+    sessions: Array.isArray(data.sessions) ? data.sessions : [],
+  };
+}
+
+/** Persist one application-state document (settings, skills, memory, …). Best-effort. */
+export async function saveStateKey(key: string, value: unknown): Promise<void> {
+  await requestJson(routeUrl(API_ROUTES.stateSet, { params: { key } }), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ value }),
+  }).catch(() => {});
+}
+
+/**
+ * Load one session's snapshot + transcript.
+ * Returns "missing" ONLY for a definitive 404 (the database has no such session).
+ * Transient failures (network, backend restarting, 5xx) THROW — callers must not
+ * mistake them for "session unknown" or they could overwrite stored history.
+ */
+export async function fetchSessionDetail(id: string): Promise<BackendSessionDetail | "missing"> {
+  const res = await resilientFetch(routeUrl(API_ROUTES.sessionGet, { params: { id } }), {
+    cache: "no-store",
+  });
+  if (res.status === 404) return "missing";
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    throw new Error((data as { error?: string }).error ?? `Request failed (${res.status})`);
+  }
+  return data as BackendSessionDetail;
+}
+
+/** Upsert a session's title and UI snapshot into the database. Best-effort. */
+export async function saveSessionSnapshot(conversation: Conversation): Promise<void> {
+  await requestJson(routeUrl(API_ROUTES.sessionSave, { params: { id: conversation.id } }), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ title: conversation.title, snapshot: conversation }),
+  }).catch(() => {});
+}
+
+/** Delete a session and all of its stored data. Best-effort. */
+export async function deleteSessionData(id: string): Promise<void> {
+  await requestJson(routeUrl(API_ROUTES.sessionDelete, { params: { id } }), {
+    method: "DELETE",
+  }).catch(() => {});
+}
+
+/**
+ * Fire a persistence write during page unload. `navigator.sendBeacon` survives the
+ * page teardown; falls back to a keepalive fetch where beacons are unavailable.
+ */
+export function beaconJson(url: string, body: unknown): void {
+  try {
+    const payload = JSON.stringify(body);
+    if (typeof navigator !== "undefined" && typeof navigator.sendBeacon === "function") {
+      const blob = new Blob([payload], { type: "application/json" });
+      if (navigator.sendBeacon(url, blob)) return;
+    }
+    void fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: payload,
+      keepalive: true,
+    }).catch(() => {});
+  } catch {
+    // best effort — the debounced sync will catch up on next boot
+  }
+}
+
+/** Beacon a session snapshot on page hide. */
+export function beaconSessionSnapshot(conversation: Conversation): void {
+  beaconJson(routeUrl(API_ROUTES.sessionSave, { params: { id: conversation.id } }), {
+    title: conversation.title,
+    snapshot: conversation,
+  });
+}
+
+/** Beacon an application-state document on page hide. */
+export function beaconStateKey(key: string, value: unknown): void {
+  beaconJson(routeUrl(API_ROUTES.stateSet, { params: { key } }), { value });
+}

--- a/frontend-main/src/lib/statePersistence.ts
+++ b/frontend-main/src/lib/statePersistence.ts
@@ -1,0 +1,275 @@
+import { useStore } from "@/store/useStore";
+import type { Conversation } from "@/types";
+import {
+  beaconSessionSnapshot,
+  beaconStateKey,
+  deleteSessionData,
+  fetchBootState,
+  fetchSessionDetail,
+  saveSessionSnapshot,
+  saveStateKey,
+} from "@/lib/backendState";
+
+/**
+ * Backend persistence bridge — replaces the old localStorage persistence entirely.
+ *
+ * Direction 1 (boot):    `bootstrapFromBackend()` hydrates the store from SQLite.
+ * Direction 2 (runtime): `startStatePersistence()` watches the store and writes every
+ *                        change back to the database — debounced for settings-like
+ *                        documents, throttled for conversation snapshots so streaming
+ *                        (60 store updates/second) never floods the network. The raw
+ *                        token stream is persisted server-side straight off the SSE
+ *                        buffer, so snapshots only need to capture structure.
+ */
+
+/** Application-state documents synced key-by-key. */
+const SYNC_KEYS = [
+  "settings",
+  "subAgents",
+  "skills",
+  "todos",
+  "memory",
+  "knowledge",
+  "knowledgeSources",
+  "customProviders",
+] as const;
+
+type SyncKey = (typeof SYNC_KEYS)[number];
+
+const KEY_DEBOUNCE_MS = 600;
+/** Snapshot sync cadence while a stream is running vs. idle. */
+const SNAPSHOT_STREAMING_MS = 10_000;
+const SNAPSHOT_IDLE_MS = 800;
+
+let started = false;
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Hydrate the store from the backend database, retrying until the backend answers.
+ * The app never runs its sync loop over in-memory defaults: doing so after a failed
+ * boot fetch would let a later edit overwrite the real stored documents (API keys,
+ * memory, skills…) with defaults.
+ */
+export async function bootstrapFromBackend() {
+  for (;;) {
+    try {
+      const payload = await fetchBootState();
+      useStore.getState().hydrateFromBackend(payload);
+      return payload;
+    } catch {
+      await sleep(1500);
+    }
+  }
+}
+
+/** Load a conversation's snapshot from the database if only a stub is present. */
+export async function loadConversationIfNeeded(id: string): Promise<Conversation | null> {
+  const existing = useStore.getState().conversations.find((c) => c.id === id);
+  if (!existing || existing.loaded !== false) return existing ?? null;
+
+  let detail: Awaited<ReturnType<typeof fetchSessionDetail>>;
+  try {
+    detail = await fetchSessionDetail(id);
+  } catch {
+    // Transient failure — keep the stub un-loaded so (a) it is retried on the next
+    // open and (b) the sync loop can never overwrite the stored snapshot with it.
+    return existing;
+  }
+  if (detail === "missing") {
+    // Definitively unknown to the database — a fresh, empty conversation.
+    useStore.getState().replaceConversation({ ...existing, loaded: true });
+    return existing;
+  }
+
+  const conv = snapshotToConversation(detail.snapshot, existing);
+
+  // Recovery: no snapshot was ever stored (e.g. the browser closed before the first
+  // sync) but the server-side transcript exists — rebuild plain messages from it.
+  // Consecutive same-role transcript entries (one per agent iteration) are merged
+  // into a single bubble so the rebuilt thread mirrors what the UI showed.
+  if (conv.messages.length === 0 && (detail.transcript ?? []).length > 0) {
+    for (const m of detail.transcript) {
+      if (m.role !== "user" && m.role !== "assistant") continue;
+      const text = textContent(m.content);
+      if (text.trim().length === 0) continue;
+      const role = m.role === "user" ? "user" : "assistant";
+      const last = conv.messages[conv.messages.length - 1];
+      if (last && last.role === role && role === "assistant") {
+        last.content += `\n\n${text}`;
+      } else {
+        conv.messages.push({
+          id: `msg_db_${conv.messages.length}_${conv.id}`,
+          role,
+          content: text,
+          createdAt: detail.session.updatedAt,
+        });
+      }
+    }
+  }
+
+  useStore.getState().replaceConversation(conv);
+  return conv;
+}
+
+function textContent(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((part) =>
+        part && typeof part === "object" && typeof (part as { text?: unknown }).text === "string"
+          ? ((part as { text: string }).text)
+          : "",
+      )
+      .join("");
+  }
+  return "";
+}
+
+/** Defensive parse of a stored snapshot into a Conversation. */
+function snapshotToConversation(snapshot: unknown, stub: Conversation): Conversation {
+  const s = (snapshot ?? {}) as Partial<Conversation>;
+  const messages = Array.isArray(s.messages)
+    ? s.messages.filter((m) => m && typeof m === "object" && typeof m.id === "string")
+    : [];
+  return {
+    id: stub.id,
+    title: typeof s.title === "string" && s.title.trim().length > 0 ? s.title : stub.title,
+    messages: messages.map((m) => ({ ...m, streaming: false })),
+    createdAt: typeof s.createdAt === "number" ? s.createdAt : stub.createdAt,
+    updatedAt: typeof s.updatedAt === "number" ? s.updatedAt : stub.updatedAt,
+    loaded: true,
+  };
+}
+
+/**
+ * Start watching the store and syncing changes into the backend database.
+ * Call once, after `bootstrapFromBackend()`.
+ */
+export function startStatePersistence(): void {
+  if (started) return;
+  started = true;
+
+  const keyTimers = new Map<SyncKey, ReturnType<typeof setTimeout>>();
+  const dirtyKeys = new Set<SyncKey>();
+
+  const convTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  const convLastSync = new Map<string, number>();
+  const dirtyConvs = new Set<string>();
+  // Baseline from the already-hydrated store so deletions are detected from the start.
+  let knownConvs = new Map<string, Conversation>(
+    useStore.getState().conversations.map((c) => [c.id, c]),
+  );
+  let currentIdTimer: ReturnType<typeof setTimeout> | null = null;
+  let currentIdDirty = false;
+
+  const scheduleKey = (key: SyncKey): void => {
+    dirtyKeys.add(key);
+    if (keyTimers.has(key)) return;
+    keyTimers.set(
+      key,
+      setTimeout(() => {
+        keyTimers.delete(key);
+        dirtyKeys.delete(key);
+        const state = useStore.getState() as unknown as Record<string, unknown>;
+        void saveStateKey(key, state[key]);
+      }, KEY_DEBOUNCE_MS),
+    );
+  };
+
+  const syncConversation = (id: string): void => {
+    dirtyConvs.delete(id);
+    const conv = useStore.getState().conversations.find((c) => c.id === id);
+    // Never sync stubs — that would overwrite the stored history with an empty doc.
+    if (!conv || conv.loaded === false) return;
+    convLastSync.set(id, Date.now());
+    void saveSessionSnapshot(conv);
+  };
+
+  const scheduleConversation = (id: string): void => {
+    dirtyConvs.add(id);
+    if (convTimers.has(id)) return;
+    const streaming = useStore.getState().streaming;
+    const interval = streaming ? SNAPSHOT_STREAMING_MS : SNAPSHOT_IDLE_MS;
+    const since = Date.now() - (convLastSync.get(id) ?? 0);
+    const delay = Math.max(streaming ? interval - since : SNAPSHOT_IDLE_MS, SNAPSHOT_IDLE_MS);
+    convTimers.set(
+      id,
+      setTimeout(() => {
+        convTimers.delete(id);
+        syncConversation(id);
+      }, delay),
+    );
+  };
+
+  useStore.subscribe((state, prev) => {
+    if (!state.hydrated) return;
+
+    // First hydrated tick: baseline the known conversations without issuing writes.
+    if (!prev.hydrated) {
+      knownConvs = new Map(state.conversations.map((c) => [c.id, c]));
+      return;
+    }
+
+    for (const key of SYNC_KEYS) {
+      if ((state as unknown as Record<string, unknown>)[key] !== (prev as unknown as Record<string, unknown>)[key]) {
+        scheduleKey(key);
+      }
+    }
+
+    if (state.currentId !== prev.currentId) {
+      currentIdDirty = true;
+      if (currentIdTimer) clearTimeout(currentIdTimer);
+      currentIdTimer = setTimeout(() => {
+        currentIdTimer = null;
+        currentIdDirty = false;
+        void saveStateKey("currentSessionId", useStore.getState().currentId);
+      }, KEY_DEBOUNCE_MS);
+    }
+
+    if (state.conversations !== prev.conversations) {
+      const next = new Map(state.conversations.map((c) => [c.id, c]));
+      for (const [id, conv] of next) {
+        const before = knownConvs.get(id);
+        if (before !== conv) scheduleConversation(id);
+      }
+      for (const id of knownConvs.keys()) {
+        if (!next.has(id)) {
+          const timer = convTimers.get(id);
+          if (timer) clearTimeout(timer);
+          convTimers.delete(id);
+          convLastSync.delete(id);
+          dirtyConvs.delete(id);
+          void deleteSessionData(id);
+        }
+      }
+      knownConvs = next;
+    }
+  });
+
+  // Durability on page close: beacon anything still pending straight into the database.
+  const flushAll = (): void => {
+    const state = useStore.getState();
+    if (!state.hydrated) return;
+    for (const key of dirtyKeys) {
+      beaconStateKey(key, (state as unknown as Record<string, unknown>)[key]);
+    }
+    dirtyKeys.clear();
+    if (currentIdDirty) {
+      beaconStateKey("currentSessionId", state.currentId);
+      currentIdDirty = false;
+    }
+    for (const id of dirtyConvs) {
+      const conv = state.conversations.find((c) => c.id === id);
+      if (conv && conv.loaded !== false) beaconSessionSnapshot(conv);
+    }
+    dirtyConvs.clear();
+  };
+
+  if (typeof window !== "undefined") {
+    window.addEventListener("pagehide", flushAll);
+    document.addEventListener("visibilitychange", () => {
+      if (document.visibilityState === "hidden") flushAll();
+    });
+  }
+}

--- a/frontend-main/src/lib/streamBatcher.ts
+++ b/frontend-main/src/lib/streamBatcher.ts
@@ -4,10 +4,10 @@ import { useStore } from "@/store/useStore";
  * Coalesces high-frequency stream deltas (assistant tokens/reasoning and each sub-agent's
  * output/reasoning) and flushes them to the store at most once per animation frame.
  *
- * This is the core render/state optimization: a fast model can emit hundreds of tokens per
+ * This is the core render/state optimization: a fast model can emit thousands of tokens per
  * second, but the UI only needs to repaint ~once per frame. Batching turns N store writes into
- * 1 per frame, which (combined with the debounced persistence layer) keeps long, streaming
- * agent responses smooth and prevents localStorage thrash.
+ * 1 per frame, keeping long, streaming agent responses smooth. Persistence happens entirely on
+ * the backend (SQLite) — the browser holds runtime state only.
  */
 export class StreamBatcher {
   private content = "";

--- a/frontend-main/src/store/useStore.ts
+++ b/frontend-main/src/store/useStore.ts
@@ -1,5 +1,4 @@
 import { create } from "zustand";
-import { persist, type StateStorage, createJSONStorage } from "zustand/middleware";
 import type {
   AskQuestionInfo,
   AskQuestionStatus,
@@ -23,7 +22,8 @@ import type {
   TodoItem,
   ToolActivity,
 } from "@/types";
-import { uid } from "@/utils/id";
+import { uid, newSessionId } from "@/utils/id";
+import type { BackendBootPayload } from "@/lib/backendState";
 import { CUSTOM_PROVIDER_PREFIX } from "@/lib/providers";
 import { DEFAULT_SUB_AGENTS, mergeSubAgentsWithDefaults } from "@/lib/defaultSubAgents";
 import { DEFAULT_SKILLS, mergeSkillsWithDefaults } from "@/lib/defaultSkills";
@@ -42,8 +42,9 @@ export type Section = "chat" | "memory" | "knowledge" | "agents" | "skills";
 export type Connection = "online" | "reconnecting" | "offline";
 
 /**
- * A run that the backend is executing independently of this browser. Persisted so that after a
- * refresh/close/reconnect the client can re-attach to the running agent and continue streaming.
+ * A run that the backend is executing independently of this browser (runtime-only).
+ * After a refresh the backend's session list (`running` flag in SQLite) tells the client
+ * which chat to re-attach to; the stream then replays from the database-backed buffer.
  */
 export interface ActiveRun {
   chatId: string;
@@ -60,7 +61,7 @@ interface StreamDelta {
 }
 
 interface AppState {
-  // Persisted
+  // Synced to the backend SQLite database (nothing is kept in browser storage)
   conversations: Conversation[];
   currentId: string | null;
   settings: Settings;
@@ -74,6 +75,8 @@ interface AppState {
   activeRun: ActiveRun | null;
 
   // Ephemeral UI
+  /** True once the store has been hydrated from the backend database. */
+  hydrated: boolean;
   section: Section;
   providers: ProviderMeta[];
   models: ModelInfo[];
@@ -87,12 +90,17 @@ interface AppState {
   preview: BrowserPreview;
   attachedFiles: AttachedFile[];
 
+  // Hydration from the backend SQLite database
+  hydrateFromBackend: (payload: BackendBootPayload) => void;
+
   // Conversations
   newConversation: () => string;
   selectConversation: (id: string) => void;
   deleteConversation: (id: string) => void;
   renameConversation: (id: string, title: string) => void;
   ensureConversation: () => string;
+  /** Replace one conversation wholesale (used when its snapshot loads from the database). */
+  replaceConversation: (conv: Conversation) => void;
 
   // Messages
   addMessage: (convId: string, message: ChatMessage) => void;
@@ -261,64 +269,14 @@ const emptyRun = (
 });
 
 /**
- * Debounced localStorage adapter: decouples the disk-write cadence from the state-update cadence
- * so streaming (which updates state ~60×/s) never floods localStorage. Writes are coalesced and
- * flushed after a short idle, and force-flushed on pagehide so the resume cursor is always durable.
+ * Runtime store. NOTHING here touches browser storage (no localStorage, no
+ * sessionStorage, no IndexedDB, no cookies): all durable data lives in the backend
+ * SQLite database. The store hydrates from `GET /api/state` at boot (see
+ * `lib/statePersistence.ts` + `hydrateFromBackend`), and every persistent slice is
+ * synced back to the database when it changes. A page refresh rebuilds the runtime
+ * state from the database and re-attaches to any still-running stream.
  */
-function createDebouncedStorage(delayMs: number): StateStorage {
-  const pending = new Map<string, string>();
-  let timer: ReturnType<typeof setTimeout> | null = null;
-
-  const flush = () => {
-    if (timer) {
-      clearTimeout(timer);
-      timer = null;
-    }
-    for (const [key, value] of pending) {
-      try {
-        localStorage.setItem(key, value);
-      } catch {
-        /* quota / private mode — best effort */
-      }
-    }
-    pending.clear();
-  };
-
-  if (typeof window !== "undefined") {
-    // Force durability before the tab goes away — critical so the resume cursor survives refresh.
-    window.addEventListener("pagehide", flush);
-    window.addEventListener("beforeunload", flush);
-    document.addEventListener("visibilitychange", () => {
-      if (document.visibilityState === "hidden") flush();
-    });
-  }
-
-  return {
-    getItem: (name) => {
-      try {
-        return localStorage.getItem(name);
-      } catch {
-        return null;
-      }
-    },
-    setItem: (name, value) => {
-      pending.set(name, value);
-      if (timer) clearTimeout(timer);
-      timer = setTimeout(flush, delayMs);
-    },
-    removeItem: (name) => {
-      pending.delete(name);
-      try {
-        localStorage.removeItem(name);
-      } catch {
-        /* ignore */
-      }
-    },
-  };
-}
-
 export const useStore = create<AppState>()(
-  persist(
     (set, get) => ({
       conversations: [],
       currentId: null,
@@ -332,6 +290,7 @@ export const useStore = create<AppState>()(
       customProviders: [],
       activeRun: null,
 
+      hydrated: false,
       section: "chat",
       providers: [],
       models: [],
@@ -345,18 +304,68 @@ export const useStore = create<AppState>()(
       preview: { url: "", open: false },
       attachedFiles: [],
 
+      hydrateFromBackend: (payload) => {
+        const state = payload.state ?? {};
+        const p = state as Partial<AppState>;
+
+        // Sessions from the database become conversation stubs; their full snapshots
+        // are fetched lazily when selected (see lib/statePersistence.ts).
+        const conversations: Conversation[] = payload.sessions.map((s) => ({
+          id: s.id,
+          title: s.title.trim().length > 0 ? s.title : "New thread",
+          messages: [],
+          createdAt: s.createdAt,
+          updatedAt: s.updatedAt,
+          messageCount: s.messageCount,
+          loaded: false,
+        }));
+
+        const storedCurrent =
+          typeof state.currentSessionId === "string" ? (state.currentSessionId as string) : null;
+        const currentId =
+          storedCurrent && conversations.some((c) => c.id === storedCurrent)
+            ? storedCurrent
+            : (conversations[0]?.id ?? null);
+
+        set((s) => ({
+          hydrated: true,
+          conversations,
+          currentId,
+          settings: { ...s.settings, ...(p.settings && typeof p.settings === "object" ? p.settings : {}) },
+          subAgents: mergeSubAgentsWithDefaults(Array.isArray(p.subAgents) ? p.subAgents : s.subAgents),
+          skills: mergeSkillsWithDefaults(Array.isArray(p.skills) ? p.skills : s.skills),
+          todos: Array.isArray(p.todos) ? p.todos : s.todos,
+          memory: mergeMemoryWithDefaults(Array.isArray(p.memory) ? p.memory : s.memory),
+          knowledge: sanitizeKnowledge(Array.isArray(p.knowledge) ? p.knowledge : s.knowledge),
+          knowledgeSources:
+            p.knowledgeSources && typeof p.knowledgeSources === "object"
+              ? (p.knowledgeSources as Record<string, KnowledgeSource>)
+              : s.knowledgeSources,
+          customProviders: Array.isArray(p.customProviders) ? p.customProviders : s.customProviders,
+        }));
+      },
+
       newConversation: () => {
-        const id = uid("conv");
+        // 20-character alphanumeric session id — the database key for this chat.
+        const id = newSessionId();
         const conv: Conversation = {
           id,
           title: "New thread",
           messages: [],
           createdAt: Date.now(),
           updatedAt: Date.now(),
+          loaded: true,
         };
         set((s) => ({ conversations: [conv, ...s.conversations], currentId: id, section: "chat" }));
         return id;
       },
+
+      replaceConversation: (conv) =>
+        set((s) => ({
+          conversations: s.conversations.some((c) => c.id === conv.id)
+            ? s.conversations.map((c) => (c.id === conv.id ? { ...conv, loaded: true } : c))
+            : [{ ...conv, loaded: true }, ...s.conversations],
+        })),
 
       ensureConversation: () => {
         const { currentId } = get();
@@ -903,41 +912,4 @@ export const useStore = create<AppState>()(
       setFilesOpen: (filesOpen) => set({ filesOpen }),
       bumpFiles: () => set((s) => ({ filesVersion: s.filesVersion + 1 })),
     }),
-    {
-      name: "haku-curro-frontend",
-      storage: createJSONStorage(() => createDebouncedStorage(400)),
-      merge: (persisted, current) => {
-        const p = (persisted ?? {}) as Partial<AppState>;
-        return {
-          ...current,
-          ...p,
-          settings: { ...current.settings, ...p.settings },
-          subAgents: mergeSubAgentsWithDefaults(Array.isArray(p.subAgents) ? p.subAgents : current.subAgents),
-          skills: mergeSkillsWithDefaults(Array.isArray(p.skills) ? p.skills : current.skills),
-          todos: Array.isArray(p.todos) ? p.todos : current.todos,
-          memory: mergeMemoryWithDefaults(Array.isArray(p.memory) ? p.memory : current.memory),
-          knowledge: sanitizeKnowledge(Array.isArray(p.knowledge) ? p.knowledge : current.knowledge),
-          knowledgeSources:
-            p.knowledgeSources && typeof p.knowledgeSources === "object"
-              ? (p.knowledgeSources as Record<string, KnowledgeSource>)
-              : current.knowledgeSources,
-          customProviders: Array.isArray(p.customProviders) ? p.customProviders : current.customProviders,
-          activeRun: p.activeRun ?? null,
-        };
-      },
-      partialize: (s) => ({
-        conversations: s.conversations,
-        currentId: s.currentId,
-        settings: s.settings,
-        subAgents: s.subAgents,
-        skills: s.skills,
-        todos: s.todos,
-        memory: s.memory,
-        knowledge: s.knowledge,
-        knowledgeSources: s.knowledgeSources,
-        customProviders: s.customProviders,
-        activeRun: s.activeRun,
-      }),
-    },
-  ),
 );

--- a/frontend-main/src/types/index.ts
+++ b/frontend-main/src/types/index.ts
@@ -19,7 +19,7 @@ export interface CustomHeader {
 }
 
 /**
- * A user-defined OpenAI-compatible provider, persisted in the browser (localStorage).
+ * A user-defined OpenAI-compatible provider, persisted in the backend SQLite database.
  * Multiple providers coexist; each can carry one or more model ids.
  */
 export interface CustomProvider {
@@ -130,7 +130,7 @@ export interface SubAgentRun {
   outputFile?: string;
 }
 
-/** A user-defined sub-agent, stored in the browser (localStorage) — never on the server. */
+/** A user-defined sub-agent, stored in the backend SQLite database. */
 export interface SubAgent {
   id: string;
   name: string;
@@ -159,7 +159,7 @@ export interface SkillFile {
 }
 
 /**
- * A user-defined skill, stored in the browser (localStorage) — never on the server. A skill is a
+ * A user-defined skill, stored in the backend SQLite database. A skill is a
  * reusable, packaged capability: a folder named after the skill containing an entry markdown file
  * (SKILL.md by default, renameable) plus any number of reference/example/script files.
  */
@@ -201,11 +201,23 @@ export interface ChatMessage {
 }
 
 export interface Conversation {
+  /** 20-character alphanumeric session id shared with the backend SQLite database. */
   id: string;
   title: string;
   messages: ChatMessage[];
   createdAt: number;
   updatedAt: number;
+  /**
+   * Server-reported message count for sessions whose full snapshot has not been
+   * fetched yet (conversation stubs listed from the database at boot).
+   */
+  messageCount?: number;
+  /**
+   * False while this conversation is only a stub from the session list — its
+   * snapshot has not been loaded from the database yet. Stubs are never synced
+   * back to the server (that would overwrite the stored history).
+   */
+  loaded?: boolean;
 }
 
 export interface FileNode {
@@ -227,7 +239,7 @@ export type TodoStatus = "pending" | "in_progress" | "completed";
 /** Priority a todo can carry. */
 export type TodoPriority = "low" | "medium" | "high";
 
-/** A single todo item in the session's task list, stored in the browser (localStorage). */
+/** A single todo item in the session's task list, stored in the backend SQLite database. */
 export interface TodoItem {
   /** Unique string identifier (starts at 1; used to refer to the todo in updates). */
   id: string;
@@ -251,7 +263,7 @@ export interface TodoToolResult {
 }
 
 /**
- * A single persistent memory file, stored in the browser (localStorage) — never on the server.
+ * A single persistent memory file, stored in the backend SQLite database.
  * `path` is relative to the virtual memory root (/memory/): a bare name ("MEMORY.md") or a nested
  * path ("projects/app.md"). The agent reads/maintains these via the `memory` tool to self-evolve
  * across chat sessions. Three files are always pre-added and permanent: MEMORY.md, SOUL.md, USER.md.
@@ -297,7 +309,7 @@ export interface MemoryToolResult {
 }
 
 /**
- * A single persistent knowledge file, stored in the browser (localStorage) — never on the server.
+ * A single persistent knowledge file, stored in the backend SQLite database.
  * `path` is relative to the virtual knowledge root (knowledge/): a bare name ("docs.md") or a nested
  * path ("api/reference.md"). The user curates the knowledge base (manual creation, file/folder
  * upload, or URL fetch); the agent reads/maintains it via the knowledge_* tools. Unlike memory, the

--- a/frontend-main/src/utils/id.ts
+++ b/frontend-main/src/utils/id.ts
@@ -6,3 +6,24 @@ export function uid(prefix = ""): string {
       : Math.random().toString(36).slice(2) + Date.now().toString(36);
   return prefix ? `${prefix}_${rand}` : rand;
 }
+
+/** Alphabet used for session ids: ALL the numbers (0-9) and ALL the letters (a-z, A-Z). */
+const SESSION_ID_ALPHABET = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+/**
+ * Generate a 20-character chat-session id (matches the backend's SQLite session ids).
+ * Uses crypto randomness when available; 62^20 possible values.
+ */
+export function newSessionId(length = 20): string {
+  const bytes = new Uint8Array(length);
+  if (typeof crypto !== "undefined" && "getRandomValues" in crypto) {
+    crypto.getRandomValues(bytes);
+  } else {
+    for (let i = 0; i < length; i += 1) bytes[i] = Math.floor(Math.random() * 256);
+  }
+  let out = "";
+  for (let i = 0; i < length; i += 1) {
+    out += SESSION_ID_ALPHABET[bytes[i]! % SESSION_ID_ALPHABET.length];
+  }
+  return out;
+}

--- a/start.sh
+++ b/start.sh
@@ -23,6 +23,7 @@ cd "$FRONTEND_DIR"
 npm install --silent
 
 echo "Starting backend (curro-ai)…"
+echo "  → SQLite database is created/opened automatically at <workspace>/.curro/curro.db"
 cd "$BACKEND_DIR"
 npm run dev > "$SCRIPT_DIR/.curro-backend.log" 2>&1 &
 BACKEND_PID=$!
@@ -34,7 +35,8 @@ FRONTEND_PID=$!
 
 echo ""
 echo "Backend  → http://localhost:8787  (health: http://localhost:8787/health)"
-echo "Frontend → http://localhost:5173  (proxies /api → backend)"
+echo "Frontend → http://localhost:5173  (proxies /api → backend, reads from the local SQLite DB)"
+echo "Database → curro-ai/workspace/.curro/curro.db (SQLite, WAL mode — auto-created)"
 echo ""
 echo "Press Ctrl+C to stop both."
 echo ""


### PR DESCRIPTION
Backend (curro-ai):
- New src/database/ module: connection (WAL, synchronous=NORMAL, cache_size=-64000, locking_mode=EXCLUSIVE, mmap, temp_store=MEMORY), schema, batched write queue with token coalescing, repositories (sessions, messages, stream events, sub-agent runs, snapshots, app state), idle-time WAL checkpoint + optimize maintenance.
- Database auto-creates at <workspace>/.curro/curro.db on boot.
- Every SSE event (main agent + sub-agent streams, tool calls/results) is persisted off the hot path via an O(1) enqueue + 200ms batched WAL transactions; consecutive token deltas coalesce into single rows (250k events enqueue in ~270ms, flush in ~20ms).
- Chat sessions use 20-char alphanumeric ids; each sub-agent invocation runs under a 10-char session id stamped on all its events.
- New /api/state and /api/sessions endpoints for frontend hydration; transcripts and event logs survive backend restarts and replay from the database when no live buffer exists.
- Session transcript source of truth: memory > SQLite > client history.

Frontend (frontend-main):
- All localStorage usage removed (zustand persist middleware, debounced storage adapter, resume cursor). No browser storage of any kind.
- Store hydrates from GET /api/state at boot (with retry); settings, API keys, skills, memory, knowledge, sub-agents, todos and custom providers sync to SQLite debounced; conversation snapshots sync throttled (10s while streaming / 800ms idle) + sendBeacon on pagehide.
- Conversations lazy-load their snapshots from the database; running streams auto-reconnect after refresh and replay in place without duplicating messages.

start.sh: note the auto-created SQLite database.