### PR TITLE
feat: add Custom Role creation applied to the Main Agent

### DIFF
--- a/frontend-main/src/app/App.tsx
+++ b/frontend-main/src/app/App.tsx
@@ -9,6 +9,7 @@ import { KnowledgePanel } from "@/components/panels/KnowledgePanel";
 import { AgentsPanel } from "@/components/panels/AgentsPanel";
 import { SkillsPanel } from "@/components/panels/SkillsPanel";
 import { TeamsPanel } from "@/components/panels/TeamsPanel";
+import { RolesPanel } from "@/components/panels/RolesPanel";
 import { SettingsModal } from "@/components/editors/SettingsModal";
 import { TodoPanel } from "@/components/overlays/TodoPanel";
 import { FilesPanel } from "@/components/overlays/FilesPanel";
@@ -94,6 +95,7 @@ export function App() {
               {section === "agents" && <AgentsPanel />}
               {section === "skills" && <SkillsPanel />}
               {section === "teams" && <TeamsPanel />}
+              {section === "roles" && <RolesPanel />}
             </div>
           )}
         </main>

--- a/frontend-main/src/components/Rail.tsx
+++ b/frontend-main/src/components/Rail.tsx
@@ -1,4 +1,4 @@
-import { MessageCircle, Brain, Library, Bot, Sparkles, Users } from "lucide-react";
+import { MessageCircle, Brain, Library, Bot, Sparkles, Users, Drama } from "lucide-react";
 import { useStore, type Section } from "@/store/useStore";
 import { cn } from "@/utils/cn";
 
@@ -9,6 +9,7 @@ const NAV: Array<{ id: Section; label: string; Icon: typeof MessageCircle }> = [
   { id: "agents", label: "Sub-agents", Icon: Bot },
   { id: "skills", label: "Skills", Icon: Sparkles },
   { id: "teams", label: "Agent teams", Icon: Users },
+  { id: "roles", label: "Custom roles", Icon: Drama },
 ];
 
 export function Rail() {

--- a/frontend-main/src/components/panels/RolesPanel.tsx
+++ b/frontend-main/src/components/panels/RolesPanel.tsx
@@ -1,0 +1,240 @@
+import { useState } from "react";
+import { Drama, Check, Pencil, Plus, Trash2 } from "lucide-react";
+import { useStore } from "@/store/useStore";
+import { Modal } from "@/components/ui/Modal";
+import { Button, EmptyState, Field, PanelHeader, TextArea, TextInput, Toggle } from "@/components/ui/primitives";
+import { isDefaultRole } from "@/lib/defaultRoles";
+import { cn } from "@/utils/cn";
+
+const NAME_MAX = 70;
+const DESC_MAX = 300;
+
+interface Draft {
+  id: string | null;
+  name: string;
+  description: string;
+  systemPrompt: string;
+  enabled: boolean;
+}
+
+const empty = (): Draft => ({ id: null, name: "", description: "", systemPrompt: "", enabled: false });
+
+/**
+ * Custom Roles panel. A Custom Role is a role/expertise/behavior overlay applied to the SAME Main
+ * Agent — NOT a new agent, sub-agent, LLM instance, or execution system. Selecting a role integrates
+ * its system prompt with the Main Agent's built-in prompt; only one role is active at a time.
+ */
+export function RolesPanel() {
+  const customRoles = useStore((s) => s.customRoles);
+  const addCustomRole = useStore((s) => s.addCustomRole);
+  const updateCustomRole = useStore((s) => s.updateCustomRole);
+  const deleteCustomRole = useStore((s) => s.deleteCustomRole);
+  const setActiveRole = useStore((s) => s.setActiveRole);
+
+  const [draft, setDraft] = useState<Draft | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const save = () => {
+    if (!draft) return;
+    const name = draft.name.trim();
+    if (!name) return setError("A role name is required.");
+    if (name.length > NAME_MAX) return setError(`Name must be ${NAME_MAX} characters or fewer.`);
+    if (draft.description.length > DESC_MAX)
+      return setError(`Description must be ${DESC_MAX} characters or fewer.`);
+    if (!draft.systemPrompt.trim()) return setError("A role system prompt is required.");
+    const clash = customRoles.some(
+      (r) => r.id !== draft.id && r.name.trim().toLowerCase() === name.toLowerCase(),
+    );
+    if (clash) return setError(`A role named "${name}" already exists.`);
+
+    const payload = {
+      name,
+      description: draft.description.trim(),
+      systemPrompt: draft.systemPrompt,
+      enabled: draft.enabled,
+    };
+    if (draft.id) updateCustomRole(draft.id, payload);
+    else addCustomRole(payload);
+    setDraft(null);
+    setError(null);
+  };
+
+  const activeRoleName = customRoles.find((r) => r.enabled)?.name ?? null;
+
+  return (
+    <div className="mx-auto w-full max-w-2xl panel-in">
+      <PanelHeader kicker="One agent, many personas" title="Custom roles" />
+      <p className="mb-4 text-sm leading-relaxed text-[var(--muted)]">
+        A Custom Role gives the Main Agent an additional role, expertise, and behavior — think Medical
+        Expert, Coding Expert, or Research Assistant. Selecting a role layers its instructions on top
+        of the same Main Agent; it does not create a new agent, and the agent keeps all of its tools
+        and abilities. Only one role is active at a time.
+      </p>
+
+      <div
+        className="mb-4 flex items-center gap-2 rounded-[var(--radius-md)] border border-[var(--border)] bg-[var(--chip)] px-3 py-2 text-xs text-[var(--muted)]"
+        aria-live="polite"
+      >
+        <Drama className="h-3.5 w-3.5 shrink-0 text-[var(--subtle)]" />
+        {activeRoleName ? (
+          <span>
+            Active role: <span className="font-medium text-[var(--fg)]">{activeRoleName}</span> — the
+            Main Agent is adopting it.
+          </span>
+        ) : (
+          <span>No role selected — the Main Agent behaves normally.</span>
+        )}
+      </div>
+
+      {customRoles.length === 0 ? (
+        <EmptyState icon={<Drama className="h-8 w-8" />}>No custom roles yet.</EmptyState>
+      ) : (
+        <ul className="grid list-none grid-cols-1 gap-3 p-0 sm:grid-cols-2">
+          {customRoles.map((role) => {
+            const isDefault = isDefaultRole(role.id);
+            return (
+              <li key={role.id}>
+                <article
+                  className={cn(
+                    "flex h-full flex-col rounded-[var(--radius-xl)] bg-[var(--bg)] p-5 transition-colors hover:bg-[var(--chip)]",
+                    role.enabled && "ring-1 ring-[var(--secondary)]",
+                  )}
+                  style={{ boxShadow: "var(--shadow-chip)" }}
+                >
+                  <div className="flex items-start justify-between gap-2">
+                    <h3 className="font-serif-display m-0 text-2xl text-[var(--fg)]">{role.name}</h3>
+                    <div className="flex items-center gap-1.5">
+                      {isDefault && (
+                        <span className="rounded-full border border-[var(--border)] px-1.5 py-0.5 text-[10px] text-[var(--subtle)]">
+                          default
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                  <p className="line-clamp-2 m-0 mt-2 text-sm leading-relaxed text-[var(--muted)]">
+                    {role.description || "No description."}
+                  </p>
+
+                  <div className="mt-3 flex items-center gap-2">
+                    <Toggle
+                      checked={role.enabled}
+                      onChange={(v) => setActiveRole(role.id, v)}
+                      label={role.enabled ? "Active role" : "Select role"}
+                    />
+                    <span className="text-xs text-[var(--muted)]">
+                      {role.enabled ? "Active" : "Select"}
+                    </span>
+                  </div>
+
+                  <div className="mt-4 flex items-center gap-1.5 border-t border-[var(--border)] pt-3">
+                    <Button
+                      variant="ghost"
+                      className="px-2"
+                      onClick={() => {
+                        setError(null);
+                        setDraft({
+                          id: role.id,
+                          name: role.name,
+                          description: role.description,
+                          systemPrompt: role.systemPrompt,
+                          enabled: role.enabled,
+                        });
+                      }}
+                    >
+                      <Pencil className="h-3.5 w-3.5" /> Edit
+                    </Button>
+                    {/* Only user-created roles can be deleted; built-in defaults cannot. */}
+                    {!isDefault && (
+                      <Button
+                        variant="ghost"
+                        className="px-2 text-[var(--subtle)] hover:text-[var(--danger)]"
+                        onClick={() => deleteCustomRole(role.id)}
+                        title="Delete role"
+                      >
+                        <Trash2 className="h-3.5 w-3.5" /> Delete
+                      </Button>
+                    )}
+                  </div>
+                </article>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      <div className="mt-4">
+        <Button
+          onClick={() => {
+            setError(null);
+            setDraft(empty());
+          }}
+        >
+          <Plus className="h-4 w-4" /> Create custom role
+        </Button>
+      </div>
+
+      <Modal
+        open={Boolean(draft)}
+        onClose={() => setDraft(null)}
+        icon={<Drama className="h-4 w-4" />}
+        title={draft?.id ? "Edit custom role" : "New custom role"}
+        size="lg"
+        footer={
+          <Button onClick={save}>
+            <Check className="h-4 w-4" /> Save
+          </Button>
+        }
+      >
+        {draft && (
+          <div className="space-y-4 p-5">
+            <Field
+              label="Role name"
+              hint={`${draft.name.length}/${NAME_MAX}`}
+              hintError={draft.name.length > NAME_MAX}
+            >
+              <TextInput
+                value={draft.name}
+                maxLength={NAME_MAX}
+                onChange={(e) => setDraft({ ...draft, name: e.target.value })}
+                placeholder="e.g. Medical Expert"
+              />
+            </Field>
+            <Field
+              label="Short role description"
+              hint={`${draft.description.length}/${DESC_MAX}`}
+              hintError={draft.description.length > DESC_MAX}
+            >
+              <TextArea
+                rows={2}
+                maxLength={DESC_MAX}
+                value={draft.description}
+                onChange={(e) => setDraft({ ...draft, description: e.target.value })}
+                placeholder="A short summary of what this role is for."
+              />
+            </Field>
+            <Field label="Role system prompt" hint="no limit">
+              <TextArea
+                rows={9}
+                value={draft.systemPrompt}
+                onChange={(e) => setDraft({ ...draft, systemPrompt: e.target.value })}
+                className="text-xs"
+                placeholder={
+                  "Define ONLY the role, expertise, behavior, rules, communication style, and task-specific instructions.\n\nDo NOT describe tools, tool usage, or execution logic — the Main Agent already has those."
+                }
+              />
+              <p className="mt-1 text-[10px] text-[var(--subtle)]">
+                Applied on top of the Main Agent's own system prompt. Describe the role and behavior
+                only — the agent keeps its existing tools, reasoning, and execution abilities.
+              </p>
+            </Field>
+            <div className="flex items-center gap-2">
+              <Toggle checked={draft.enabled} onChange={(v) => setDraft({ ...draft, enabled: v })} />
+              <span className="text-sm text-[var(--muted)]">Select this role (apply to the Main Agent)</span>
+            </div>
+            {error && <p className="text-xs text-[var(--danger)]">{error}</p>}
+          </div>
+        )}
+      </Modal>
+    </div>
+  );
+}

--- a/frontend-main/src/hooks/useChatStream.ts
+++ b/frontend-main/src/hooks/useChatStream.ts
@@ -6,6 +6,7 @@ import { dispatchStreamEvent } from "@/lib/streamDispatch";
 import { attachLatestMemoryAgentRun } from "@/lib/memoryAgent";
 import { CUSTOM_PROVIDER_PREFIX, toCustomProviderConfig } from "@/lib/providers";
 import { activeTeam } from "@/lib/defaultTeams";
+import { activeRole, toBackendRole } from "@/lib/defaultRoles";
 import { useStore, type ActiveRun } from "@/store/useStore";
 import { uid } from "@/utils/id";
 import type {
@@ -70,6 +71,15 @@ function buildStartRequest(convId: string, text: string): StreamRequest {
   const memory: MemoryFile[] = store.memory;
   const knowledge: KnowledgeFile[] = store.knowledge;
 
+  // Custom Role: when the user has selected a role, send it so the SAME Main Agent adopts its
+  // role/expertise/behavior for this turn. Only roles carrying an actual system prompt are sent;
+  // when no role is active, nothing is sent and the Main Agent behaves exactly as before.
+  const selectedRole = activeRole(store.customRoles);
+  const customRole =
+    selectedRole && selectedRole.systemPrompt.trim().length > 0
+      ? toBackendRole(selectedRole)
+      : undefined;
+
   // Multi-agent team mode: when enabled and a team is active, route the turn through the team head.
   const teamsEnabled = settings.enableAgentTeams === "yes";
   const team = teamsEnabled ? activeTeam(store.agentTeams) : null;
@@ -114,6 +124,7 @@ function buildStartRequest(convId: string, text: string): StreamRequest {
     memory,
     knowledge,
     enable_reuse_sub_agent_session: settings.enableReuseSubAgentSession === "yes" ? "yes" : "no",
+    custom_role: customRole,
     multi_agent: Boolean(backendTeam),
     agent_team: backendTeam,
     enable_send_message_to_team: settings.enableSendMessageToTeam === "yes" ? "yes" : "no",

--- a/frontend-main/src/lib/defaultRoles.ts
+++ b/frontend-main/src/lib/defaultRoles.ts
@@ -1,0 +1,190 @@
+import type { BackendCustomRole, CustomRole } from "@/types";
+
+/**
+ * Custom Roles — a role/expertise/behavior overlay applied to the SAME Main Agent.
+ *
+ * A Custom Role is NOT a new agent, sub-agent, LLM instance, or execution system. When a role is
+ * active (enabled), its system prompt is integrated with the Main Agent's built-in system prompt so
+ * the same agent adopts the role's expertise, behavior, rules, and communication style. The agent's
+ * tools, tool-usage rules, reasoning, and execution architecture stay fully intact.
+ *
+ * A set of ready-to-use default roles is pre-added (disabled) so the feature is useful immediately,
+ * mirroring how default sub-agents / skills / teams are merged in. Defaults have ids prefixed with
+ * "default-" and cannot be deleted (only disabled/edited). No role is active by default, so the Main
+ * Agent behaves exactly as before until the user selects one.
+ */
+
+const FIXED_CREATED_AT = 0;
+const FIXED_UPDATED_AT = 1;
+
+interface RoleSeed {
+  id: string;
+  name: string;
+  description: string;
+  systemPrompt: string;
+}
+
+const SEEDS: readonly RoleSeed[] = [
+  {
+    id: "default-general-assistant",
+    name: "General Assistant",
+    description: "A helpful, well-rounded generalist for everyday questions and tasks.",
+    systemPrompt: `You are acting as a General Assistant.
+
+Expertise & behavior:
+- Be a helpful, knowledgeable, and reliable generalist across a wide range of everyday topics and tasks.
+- Give clear, direct, well-organized answers; adapt depth to the user's apparent expertise.
+- When a request is ambiguous, make sensible assumptions and state them, or ask a brief clarifying question when it truly matters.
+
+Communication style:
+- Warm, concise, and professional. Prefer short paragraphs and lists over long walls of text.
+- Explain your reasoning at a high level when it helps the user trust and follow the answer.`,
+  },
+  {
+    id: "default-coding-expert",
+    name: "Coding Expert",
+    description: "A senior software engineer focused on clean, correct, production-quality code.",
+    systemPrompt: `You are acting as a Coding Expert — a senior software engineer.
+
+Expertise & behavior:
+- Write clean, correct, idiomatic, production-quality code and follow the conventions already present in the project.
+- Reason carefully about edge cases, error handling, performance, and maintainability.
+- Prefer the simplest solution that fully solves the problem; avoid over-engineering.
+- Explain non-obvious decisions and trade-offs briefly.
+
+Rules:
+- Never leave stubs or placeholders when a complete implementation is expected.
+- Verify your work (build/tests/run) when possible and fix what you find.
+
+Communication style:
+- Precise and technical, but approachable. Lead with the solution, then the rationale.`,
+  },
+  {
+    id: "default-research-assistant",
+    name: "Research Assistant",
+    description: "A rigorous researcher who finds, verifies, and synthesizes information.",
+    systemPrompt: `You are acting as a Research Assistant.
+
+Expertise & behavior:
+- Investigate topics thoroughly and objectively; distinguish established facts from opinion or speculation.
+- Cross-check important claims and prefer authoritative, up-to-date sources.
+- Synthesize findings into clear, structured briefings; note uncertainties, gaps, and conflicting evidence.
+
+Rules:
+- Never fabricate sources, quotes, figures, or citations. If something cannot be verified, say so.
+
+Communication style:
+- Structured and neutral: an executive summary first, then findings grouped by theme, then caveats.`,
+  },
+  {
+    id: "default-writing-assistant",
+    name: "Writing Assistant",
+    description: "A skilled writer and editor for clear, compelling, well-structured prose.",
+    systemPrompt: `You are acting as a Writing Assistant.
+
+Expertise & behavior:
+- Produce clear, engaging, well-structured writing tailored to the requested audience, purpose, and tone.
+- Improve drafts for clarity, flow, grammar, and impact while preserving the author's voice and intent.
+- Offer alternative phrasings or structures when useful, and explain edits briefly when asked.
+
+Communication style:
+- Adapt register to the task (formal, casual, technical, marketing, etc.).
+- Favor precise, natural language; cut filler and redundancy.`,
+  },
+  {
+    id: "default-medical-expert",
+    name: "Medical Expert",
+    description: "A knowledgeable medical information assistant (educational, not a substitute for care).",
+    systemPrompt: `You are acting as a Medical Expert providing clear, evidence-based health information.
+
+Expertise & behavior:
+- Explain medical concepts, conditions, treatments, and research accurately and in plain language.
+- Ground answers in mainstream, evidence-based medicine; note when evidence is limited or evolving.
+- Be careful and precise; distinguish general information from individual medical advice.
+
+Rules:
+- Always include a brief reminder that this is general educational information, not a diagnosis or a substitute for a qualified healthcare professional.
+- For emergencies or serious symptoms, advise the user to seek professional or emergency care.
+- Do not fabricate studies, dosages, or guidelines; if unsure, say so.
+
+Communication style:
+- Empathetic, calm, and professional. Clear structure, defined terms, and no unnecessary alarm.`,
+  },
+];
+
+/** Ready-to-use default roles, pre-added but disabled (no role is active until the user selects one). */
+export const DEFAULT_ROLES: readonly CustomRole[] = SEEDS.map((seed) => ({
+  id: seed.id,
+  name: seed.name,
+  description: seed.description,
+  systemPrompt: seed.systemPrompt.trim(),
+  enabled: false,
+  createdAt: FIXED_CREATED_AT,
+  updatedAt: FIXED_UPDATED_AT,
+}));
+
+/** Built-in default roles have ids prefixed with "default-" and can never be deleted. */
+export function isDefaultRole(id: string): boolean {
+  return id.startsWith("default-");
+}
+
+/** Defensive normalize of a stored role into a well-formed CustomRole. */
+function normalizeRole(role: CustomRole): CustomRole {
+  return {
+    id: role.id,
+    name: typeof role.name === "string" ? role.name : "Custom role",
+    description: typeof role.description === "string" ? role.description : "",
+    systemPrompt: typeof role.systemPrompt === "string" ? role.systemPrompt : "",
+    enabled: role.enabled === true,
+    createdAt: typeof role.createdAt === "number" ? role.createdAt : Date.now(),
+    updatedAt: typeof role.updatedAt === "number" ? role.updatedAt : Date.now(),
+  };
+}
+
+/**
+ * Merge persisted (user) roles with the default set so the defaults are pre-added for every user,
+ * unless the user already has a role with the same id (which then wins). Ensures at most one role is
+ * enabled at a time.
+ */
+export function mergeRolesWithDefaults(userRoles: CustomRole[]): CustomRole[] {
+  const seen = new Set<string>();
+  const result: CustomRole[] = [];
+  for (const role of Array.isArray(userRoles) ? userRoles : []) {
+    if (!role || typeof role !== "object" || typeof role.id !== "string") continue;
+    if (seen.has(role.id)) continue;
+    seen.add(role.id);
+    result.push(normalizeRole(role));
+  }
+  for (const role of DEFAULT_ROLES) {
+    if (seen.has(role.id)) continue;
+    seen.add(role.id);
+    result.push({ ...role });
+  }
+  return enforceSingleActiveRole(result);
+}
+
+/** Ensure at most one role is enabled; the first enabled role wins, the rest are disabled. */
+export function enforceSingleActiveRole(roles: CustomRole[]): CustomRole[] {
+  let activeSeen = false;
+  return roles.map((r) => {
+    if (r.enabled && !activeSeen) {
+      activeSeen = true;
+      return r;
+    }
+    return r.enabled ? { ...r, enabled: false } : r;
+  });
+}
+
+/** The active (enabled) role, or null. */
+export function activeRole(roles: CustomRole[]): CustomRole | null {
+  return roles.find((r) => r.enabled) ?? null;
+}
+
+/** Convert a role into the backend/wire format sent with a turn. */
+export function toBackendRole(role: CustomRole): BackendCustomRole {
+  return {
+    name: role.name.trim(),
+    description: role.description.trim(),
+    system_prompt: role.systemPrompt,
+  };
+}

--- a/frontend-main/src/lib/statePersistence.ts
+++ b/frontend-main/src/lib/statePersistence.ts
@@ -33,6 +33,7 @@ const SYNC_KEYS = [
   "knowledgeSources",
   "customProviders",
   "agentTeams",
+  "customRoles",
 ] as const;
 
 type SyncKey = (typeof SYNC_KEYS)[number];

--- a/frontend-main/src/store/useStore.ts
+++ b/frontend-main/src/store/useStore.ts
@@ -8,6 +8,7 @@ import type {
   ChatMessage,
   Conversation,
   CustomProvider,
+  CustomRole,
   FetchProvider,
   KnowledgeFile,
   KnowledgeSource,
@@ -45,9 +46,10 @@ import {
 } from "@/lib/defaultMemory";
 import { hasUnsafeSegment, normalizeKnowledgePath, sanitizeKnowledge } from "@/lib/defaultKnowledge";
 import { enforceSingleActive, mergeTeamsWithDefaults } from "@/lib/defaultTeams";
+import { enforceSingleActiveRole, mergeRolesWithDefaults } from "@/lib/defaultRoles";
 
 /** The workspace sections the rail switches between. */
-export type Section = "chat" | "memory" | "knowledge" | "agents" | "skills" | "teams";
+export type Section = "chat" | "memory" | "knowledge" | "agents" | "skills" | "teams" | "roles";
 
 /** Connection state surfaced to the user. Slow ≠ offline; only a lost connection is "offline". */
 export type Connection = "online" | "reconnecting" | "offline";
@@ -84,6 +86,7 @@ interface AppState {
   knowledgeSources: Record<string, KnowledgeSource>;
   customProviders: CustomProvider[];
   agentTeams: AgentTeam[];
+  customRoles: CustomRole[];
   activeRun: ActiveRun | null;
 
   // Ephemeral UI
@@ -229,6 +232,13 @@ interface AppState {
   deleteTeam: (id: string) => void;
   /** Activate a team (turns off any other active team — only one team is active at a time). */
   setActiveTeam: (id: string, enabled: boolean) => void;
+
+  // Custom role management (a role/behavior overlay applied to the SAME Main Agent)
+  addCustomRole: (input: Omit<CustomRole, "id" | "createdAt" | "updatedAt">) => void;
+  updateCustomRole: (id: string, patch: Partial<Omit<CustomRole, "id" | "createdAt">>) => void;
+  deleteCustomRole: (id: string) => void;
+  /** Select a role (turns off any other active role — only one role is applied at a time). */
+  setActiveRole: (id: string, enabled: boolean) => void;
 
   // Multi-agent team live run (rendered inline in the assistant container message)
   startTeamRun: (
@@ -466,6 +476,7 @@ export const useStore = create<AppState>()(
       knowledgeSources: {},
       customProviders: [],
       agentTeams: mergeTeamsWithDefaults([]),
+      customRoles: mergeRolesWithDefaults([]),
       activeRun: null,
 
       hydrated: false,
@@ -532,6 +543,11 @@ export const useStore = create<AppState>()(
             Array.isArray((p as { agentTeams?: unknown }).agentTeams)
               ? ((p as { agentTeams?: AgentTeam[] }).agentTeams as AgentTeam[])
               : s.agentTeams,
+          ),
+          customRoles: mergeRolesWithDefaults(
+            Array.isArray((p as { customRoles?: unknown }).customRoles)
+              ? ((p as { customRoles?: CustomRole[] }).customRoles as CustomRole[])
+              : s.customRoles,
           ),
         }));
       },
@@ -991,6 +1007,36 @@ export const useStore = create<AppState>()(
               : enabled
                 ? { ...t, enabled: false } // only one team active at a time
                 : t,
+          ),
+        })),
+
+      // ---- Custom role management ------------------------------------------------
+      addCustomRole: (input) =>
+        set((s) => {
+          const now = Date.now();
+          const role: CustomRole = { id: uid("role"), createdAt: now, updatedAt: now, ...input };
+          // A brand-new active role must deactivate any other active role.
+          return { customRoles: enforceSingleActiveRole([role, ...s.customRoles]) };
+        }),
+
+      updateCustomRole: (id, patch) =>
+        set((s) => ({
+          customRoles: enforceSingleActiveRole(
+            s.customRoles.map((r) => (r.id === id ? { ...r, ...patch, updatedAt: Date.now() } : r)),
+          ),
+        })),
+
+      deleteCustomRole: (id) =>
+        set((s) => ({ customRoles: s.customRoles.filter((r) => r.id !== id) })),
+
+      setActiveRole: (id, enabled) =>
+        set((s) => ({
+          customRoles: s.customRoles.map((r) =>
+            r.id === id
+              ? { ...r, enabled, updatedAt: Date.now() }
+              : enabled
+                ? { ...r, enabled: false } // only one role applied at a time
+                : r,
           ),
         })),
 

--- a/frontend-main/src/types/index.ts
+++ b/frontend-main/src/types/index.ts
@@ -228,6 +228,38 @@ export interface AgentTeam {
   updatedAt: number;
 }
 
+/**
+ * A user-defined Custom Role, stored in the backend SQLite database (app_state `customRoles`).
+ * A Custom Role is NOT a separate agent, sub-agent, LLM instance, or execution system — it is only
+ * a role/expertise/behavior overlay applied to the SAME Main Agent. When a role is active (enabled),
+ * its `systemPrompt` is integrated with the Main Agent's built-in system prompt for the turn. At most
+ * one role may be active at a time.
+ */
+export interface CustomRole {
+  id: string;
+  /** Human-readable role name, e.g. "Medical Expert". */
+  name: string;
+  /** Short description of the role. */
+  description: string;
+  /**
+   * The role's system prompt: role, expertise, behavior, rules, communication style, and
+   * task-specific instructions ONLY. It must not define tools, tool usage, or execution logic —
+   * the Main Agent already owns those.
+   */
+  systemPrompt: string;
+  /** Whether this role is the active one applied to the Main Agent (only one active at a time). */
+  enabled: boolean;
+  createdAt: number;
+  updatedAt: number;
+}
+
+/** Custom-role definition in the backend/wire format sent with a turn when a role is active. */
+export interface BackendCustomRole {
+  name: string;
+  description: string;
+  system_prompt: string;
+}
+
 /** Agent-team definition in the backend/wire format sent with each turn. */
 export interface BackendTeam {
   id: string;
@@ -636,6 +668,11 @@ export interface StreamRequest {
   knowledge?: KnowledgeFile[];
   /** Mirrors settings.enableReuseSubAgentSession; gates the sub-agent session tools this turn. */
   enable_reuse_sub_agent_session?: "no" | "yes";
+  /**
+   * The active Custom Role applied to the Main Agent this turn (present only when a role is
+   * selected). A role/expertise/behavior overlay — never a separate agent or model.
+   */
+  custom_role?: BackendCustomRole;
   /** When true, run this turn as a multi-agent team (with agent_team) instead of a single agent. */
   multi_agent?: boolean;
   /** The active agent team definition sent when multi_agent is true. */

--- a/gptloop/src/agents/agent.ts
+++ b/gptloop/src/agents/agent.ts
@@ -1,5 +1,5 @@
 import type { AppConfig } from "../config.js";
-import { buildSystemPrompt } from "./systemprompt.js";
+import { buildSystemPrompt, type CustomRoleConfig } from "./systemprompt.js";
 import type { ProviderRegistry } from "./providers/registry.js";
 import { resolveProvider } from "./providers/registry.js";
 import type { Provider } from "./providers/types.js";
@@ -71,6 +71,13 @@ export interface RunAgentRequest {
    * tools are hidden from the model and their usage guidance is omitted from the system prompt.
    */
   enableReuseSubAgentSession?: boolean;
+  /**
+   * An optional Custom Role selected by the user. When present, its role/expertise/behavior is
+   * appended to and integrated with THIS Main Agent's system prompt so the same agent adopts the
+   * role. It never creates a new agent, sub-agent, or model; the agent's tools, execution, and
+   * reasoning architecture stay fully intact.
+   */
+  customRole?: CustomRoleConfig | null;
 }
 
 /**
@@ -165,6 +172,7 @@ export class AgentRunner {
       const reuseSessionsEnabled = request.enableReuseSubAgentSession === true;
       const systemPrompt = buildSystemPrompt(this.config.workspaceRoot, {
         enableReuseSubAgentSession: reuseSessionsEnabled,
+        customRole: request.customRole ?? null,
       });
       // Expose the sub-agent session tools to the model only when the setting is on. Everything else
       // in the registry is always available; the two session tools are filtered out otherwise.

--- a/gptloop/src/agents/systemprompt.ts
+++ b/gptloop/src/agents/systemprompt.ts
@@ -1,3 +1,19 @@
+/**
+ * A user-authored Custom Role: an additional layer of role, expertise, and behavioral
+ * instructions applied to the SAME Main Agent. It is NOT a new agent, sub-agent, LLM
+ * instance, or execution system — only a persona/behavior overlay. `systemPrompt` carries
+ * the role's own instructions (role, expertise, behavior, rules, communication style, task
+ * instructions); it must NOT redefine tools, tool usage, or execution architecture.
+ */
+export interface CustomRoleConfig {
+  /** Human-readable role name, e.g. "Medical Expert". */
+  name?: string;
+  /** Short description of the role. */
+  description?: string;
+  /** The role's system prompt (role/expertise/behavior/rules/communication/task instructions). */
+  systemPrompt: string;
+}
+
 export interface SystemPromptOptions {
   /**
    * Whether the two sub-agent session tools (list_sub_agent_sessions / reuse_same_sub_agent_session)
@@ -5,6 +21,41 @@ export interface SystemPromptOptions {
    * (and the tools are not exposed to the model), matching the user's Settings choice.
    */
   enableReuseSubAgentSession?: boolean;
+  /**
+   * An optional Custom Role selected by the user. When present, its role/expertise/behavior is
+   * appended to (and integrated with) THIS Main Agent's system prompt so the same agent adopts the
+   * role. The agent's identity, tools, tool-usage rules, reasoning/ReAct loop, and execution
+   * architecture all remain fully intact; the role only shapes expertise, behavior, and style.
+   */
+  customRole?: CustomRoleConfig | null;
+}
+
+/**
+ * Build the "Active custom role" section appended to the Main Agent's system prompt. Returns an
+ * empty string when no valid role is provided (empty role prompt → nothing appended). The section
+ * is framed so the role layers ON TOP of the agent without ever overriding its operational rules.
+ */
+function buildCustomRoleSection(role: CustomRoleConfig | null | undefined): string {
+  if (!role) return "";
+  const rolePrompt = (role.systemPrompt ?? "").trim();
+  if (rolePrompt.length === 0) return "";
+
+  const name = (role.name ?? "").trim();
+  const description = (role.description ?? "").trim();
+  const header = name.length > 0 ? `Role: ${name}` : "Role: (unnamed custom role)";
+  const descriptionLine = description.length > 0 ? `\nDescription: ${description}` : "";
+
+  return `
+
+# Active custom role
+The user has selected a Custom Role for you to adopt for this conversation. A Custom Role is NOT a separate agent, sub-agent, model, or execution system — it is an additional layer of role, expertise, and behavior applied to YOU, the same GPTLoop Main Agent. Everything described above about your identity, environment, tools, tool-usage rules, reasoning/ReAct loop, and execution architecture stays fully in effect and takes precedence; the role must never be treated as permission to change or ignore those operational rules.
+
+Adopt the role below and let it shape your expertise, behavior, rules, communication style, and how you approach and solve the user's tasks. You remain responsible for all execution, reasoning, tool calling, and task processing exactly as defined above. If any role instruction conflicts with the tool-usage or execution rules above, those operational rules win; otherwise follow the role faithfully and consistently for the whole conversation.
+
+${header}${descriptionLine}
+
+Role instructions:
+${rolePrompt}`;
 }
 
 export function buildSystemPrompt(
@@ -200,5 +251,5 @@ It is important to remember:
 - When a tool is needed, call it — do not narrate fake results.
 - When no tool is needed, answer the user directly.
 - When the task is complete, give a short, clear summary of what you did.
-`.trim();
+`.trim() + buildCustomRoleSection(options.customRole);
 }

--- a/gptloop/src/api/chat.ts
+++ b/gptloop/src/api/chat.ts
@@ -1,6 +1,7 @@
 import { Router, type Request, type Response } from "express";
 import type { AppConfig } from "../config.js";
 import { AgentRunner, type RunAgentRequest } from "../agents/agent.js";
+import type { CustomRoleConfig } from "../agents/systemprompt.js";
 import { SessionEventBuffer } from "../services/eventBuffer.js";
 import type { SessionStore, StoredMessage } from "../services/sessionStore.js";
 import type { PlanApprovalStore } from "../services/planApprovalStore.js";
@@ -67,6 +68,11 @@ interface StreamBody {
   memory?: unknown;
   knowledge?: unknown;
   enable_reuse_sub_agent_session?: unknown;
+  /**
+   * The active Custom Role selected in the frontend, applied to the SAME Main Agent this turn.
+   * A role/expertise/behavior overlay on the existing agent — never a new agent or model.
+   */
+  custom_role?: unknown;
   /** When true (with a valid agent_team), run this turn as a multi-agent team instead of one agent. */
   multi_agent?: unknown;
   /** The active agent team definition (head + members) sent from the frontend. */
@@ -107,6 +113,28 @@ function normalizeTeam(raw: unknown): AgentTeamDefinition | null {
     leader_system_prompt:
       typeof record.leader_system_prompt === "string" ? record.leader_system_prompt : "",
     members,
+  };
+}
+
+/**
+ * Defensively coerce the client-provided Custom Role into a safe value, or `null`. A role only
+ * counts when it carries a non-empty system prompt (accepts either `system_prompt` or the camelCase
+ * `systemPrompt`). Name and description are optional trimmed strings.
+ */
+function normalizeCustomRole(raw: unknown): CustomRoleConfig | null {
+  if (!raw || typeof raw !== "object") return null;
+  const record = raw as Record<string, unknown>;
+  const systemPrompt =
+    typeof record.system_prompt === "string"
+      ? record.system_prompt
+      : typeof record.systemPrompt === "string"
+        ? (record.systemPrompt as string)
+        : "";
+  if (systemPrompt.trim().length === 0) return null;
+  return {
+    name: typeof record.name === "string" ? record.name.trim() : "",
+    description: typeof record.description === "string" ? record.description.trim() : "",
+    systemPrompt,
   };
 }
 
@@ -404,6 +432,7 @@ export function buildChatRouter(
         enableReuseSubAgentSession:
           body.enable_reuse_sub_agent_session === true ||
           body.enable_reuse_sub_agent_session === "yes",
+        customRole: normalizeCustomRole(body.custom_role),
       };
 
       // Fire-and-forget the autonomous agent loop; the response streams from the buffer.

--- a/gptloop/src/database/repositories/appStateRepo.ts
+++ b/gptloop/src/database/repositories/appStateRepo.ts
@@ -19,6 +19,7 @@ export const APP_STATE_KEYS = [
   "customProviders",
   "currentSessionId",
   "agentTeams",
+  "customRoles",
 ] as const;
 
 export type AppStateKey = (typeof APP_STATE_KEYS)[number];


### PR DESCRIPTION
Add a Custom Role feature: users create roles (name, short description, system prompt) from a new sidebar section and select one to apply. The selected role's system prompt is integrated with the existing Main Agent's built-in system prompt so the same agent adopts the role, expertise, behavior, rules and communication style.

A Custom Role is only a behavior/persona overlay — it does NOT create a new main agent, sub-agent, multi-agent team, separate LLM instance, or execution system. The Main Agent keeps its full identity, tools, tool-usage rules, reasoning/ReAct loop and execution architecture; operational rules always take precedence over role instructions.

Backend (gptloop):
- systemprompt.ts: CustomRoleConfig + append an 'Active custom role' section
- agent.ts: forward request.customRole into buildSystemPrompt
- api/chat.ts: accept + defensively normalize custom_role from the wire
- appStateRepo.ts: persist the new customRoles app-state key

Frontend (frontend-main):
- defaultRoles.ts: pre-added default roles + single-active helpers
- RolesPanel + Rail button + App wiring for the new 'roles' section
- store: customRoles state, add/update/delete/select (single active) + hydrate
- statePersistence: sync customRoles; useChatStream sends the active role