### PR TITLE
feat(providers): add APInex model provider

### DIFF
--- a/frontend-main/src/lib/providers.ts
+++ b/frontend-main/src/lib/providers.ts
@@ -69,4 +69,5 @@ export const FALLBACK_PROVIDERS: ProviderMeta[] = [
   { id: "sealion", label: "SEA-LION", defaultBaseUrl: "https://api.sea-lion.ai/v1" },
   { id: "openadapter", label: "OpenAdapter", defaultBaseUrl: "https://api.openadapter.in/v1" },
   { id: "xkiro", label: "xKiro AI", defaultBaseUrl: "https://api.xkiro.com/v1" },
+  { id: "apinex", label: "APInex", defaultBaseUrl: "https://api.apinex.bond/v1" },
 ];

--- a/gptloop/src/agents/providers/apinex.ts
+++ b/gptloop/src/agents/providers/apinex.ts
@@ -1,0 +1,16 @@
+import { OpenAICompatibleProvider } from "./base.js";
+
+/**
+ * APInex (https://apinex.bond/developers) is an OpenAI-compatible gateway ("one API for
+ * every model") exposing `chat/completions`, `models`, and a `messages` surface (we only
+ * use the OpenAI one) at `https://api.apinex.bond/v1`. It authenticates with a standard
+ * `Authorization: Bearer` token (it also accepts `x-api-key`).
+ *
+ * Its `/models` endpoint returns the standard OpenAI `{ object: "list", data: [...] }`
+ * catalog, so the base provider's parser handles model discovery and streaming as-is.
+ */
+export const apinexProvider = new OpenAICompatibleProvider({
+  id: "apinex",
+  label: "APInex",
+  defaultBaseUrl: "https://api.apinex.bond/v1",
+});

--- a/gptloop/src/agents/providers/registry.ts
+++ b/gptloop/src/agents/providers/registry.ts
@@ -31,6 +31,7 @@ import { sarvamProvider } from "./sarvam.js";
 import { sealionProvider } from "./sealion.js";
 import { openadapterProvider } from "./openadapter.js";
 import { xkiroProvider } from "./xkiro.js";
+import { apinexProvider } from "./apinex.js";
 
 /**
  * ProviderRegistry maps a provider id to a Provider implementation.
@@ -100,6 +101,7 @@ export const ALL_PROVIDERS: Provider[] = [
   sealionProvider,
   openadapterProvider,
   xkiroProvider,
+  apinexProvider,
 ];
 
 export function createProviderRegistry(): ProviderRegistry {


### PR DESCRIPTION
Add APInex (https://apinex.bond/developers), an OpenAI-compatible gateway at https://api.apinex.bond/v1 (Bearer / x-api-key auth) exposing a standard /v1/chat/completions and /v1/models catalog. Users paste their API key in Settings, fetch the live model list, select a model, and chat like any other built-in provider.

Registered in both the backend registry and the frontend fallback list. Only APInex is added — no other providers or systems are touched.